### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/lib/generate-book-pdf.tsx
+++ b/src/lib/generate-book-pdf.tsx
@@ -1,6 +1,14 @@
 import { Book, Entry, Chapter, BookTheme, BOOK_THEMES } from './types';
 import { getEntryTitle, formatDate } from './entries';
 
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 const getThemeStyles = (theme: BookTheme) => {
   const styles: Record<BookTheme, {
     coverBg: string;
@@ -162,7 +170,7 @@ export async function generateBookPDF(
     <!DOCTYPE html>
     <html>
     <head>
-      <title>${book.title}</title>
+      <title>${escapeHtml(book.title)}</title>
       <style>
         @media print {
           @page {


### PR DESCRIPTION
Potential fix for [https://github.com/MagnusJerono/memory-journal/security/code-scanning/1](https://github.com/MagnusJerono/memory-journal/security/code-scanning/1)

In general, the problem is that untrusted text (`book.title`) is being injected directly into HTML markup via a template literal used with `document.write`. To fix this, any untrusted text that ends up in HTML must be properly HTML-escaped before insertion so that it is treated as text, not markup or script. The same applies to any other user-controlled strings included in the generated HTML.

The minimal, non-breaking fix is to introduce a small HTML-escaping helper in `src/lib/generate-book-pdf.tsx` and use it at the point where `book.title` is interpolated into the `<title>` element (and optionally any other obvious text insertions you want to harden). We should not change existing external APIs or behavior beyond converting dangerous characters (`&`, `<`, `>`, `"`, and `'`) into their HTML entity equivalents. Concretely, in `src/lib/generate-book-pdf.tsx`:

1. Add a local function, e.g. `escapeHtml`, near the top of the file (after imports) that replaces dangerous characters with HTML entities.
2. Update the `<title>${book.title}</title>` line inside the `printWindow.document.write` template to `<title>${escapeHtml(book.title)}</title>`. This ensures user-supplied content cannot break out of the `<title>` context.
3. Optionally, for defense in depth, you could also escape any other user-controllable strings injected into HTML in this function (e.g., if `generateCoverHTML` or other functions ever pass raw user content into HTML), but per instructions we’ll only modify the shown snippet.

No changes are needed in `PrintScreen.tsx` for the core issue; the vulnerability is at the sink in `generate-book-pdf.tsx`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
