### PR TITLE
fix: remove x-user-id spoofing vector and enforce RLS via user JWT

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,12 +1,10 @@
 // Shared authentication helper for API endpoints.
 //
-// Validates user identity from the Authorization header (Bearer token) or the
-// legacy x-user-id header used by the Spark runtime.
+// Validates user identity from the Authorization: Bearer header.
 //
 // To enable full Supabase JWT verification, set the SUPABASE_URL and
-// SUPABASE_SERVICE_ROLE_KEY environment variables. The helper will then call
-// supabase.auth.getUser(token) to verify the JWT and extract the canonical user
-// identity before falling back to the raw token value.
+// SUPABASE_SERVICE_ROLE_KEY environment variables. The helper will then verify
+// the JWT via Supabase and extract the canonical user ID from the token payload.
 
 export interface AuthenticatedUser {
   id: string;
@@ -19,22 +17,17 @@ function normalizeIdentity(rawIdentity: string): string {
 /**
  * Extracts a verified user identity from the request.
  *
- * Priority order:
- *   1. Authorization: Bearer <token>  — the token is used as the user identity
- *      (and validated via Supabase when SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY
- *      are configured).
- *   2. x-user-id header — legacy / GitHub Spark runtime header.
+ * Reads the Authorization: Bearer <token> header. When SUPABASE_URL and
+ * SUPABASE_SERVICE_ROLE_KEY are configured the token is verified via Supabase
+ * and the canonical user ID is returned.
  *
- * Returns null when no identity can be determined.
+ * Returns null when no valid identity can be determined.
  */
 export async function extractUser(req: any): Promise<AuthenticatedUser | null> {
-  // 1. Authorization: Bearer <token>
   const authHeader = req.headers?.['authorization'] as string | undefined;
   if (authHeader?.startsWith('Bearer ')) {
     const token = authHeader.slice(7).trim();
     if (token.length > 0) {
-      // When Supabase credentials are present, verify the JWT and use the
-      // canonical user ID from the token payload.
       const supabaseUrl = process.env.SUPABASE_URL;
       const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
       if (supabaseUrl && serviceRoleKey) {
@@ -63,12 +56,6 @@ export async function extractUser(req: any): Promise<AuthenticatedUser | null> {
       // No Supabase credentials — accept the token opaquely as the user identity.
       return { id: normalizeIdentity(token) };
     }
-  }
-
-  // 2. Fallback: x-user-id header (Spark runtime / legacy clients).
-  const userId = req.headers?.['x-user-id'] as string | undefined;
-  if (userId && userId.trim().length > 0) {
-    return { id: normalizeIdentity(userId) };
   }
 
   return null;

--- a/api/preferences.ts
+++ b/api/preferences.ts
@@ -46,18 +46,37 @@ type SupabasePrefsRow = {
   updated_at: string;
 };
 
+/**
+ * Makes an authenticated request to the Supabase REST API.
+ *
+ * When a userToken (the caller's Supabase JWT) is provided it is used as the
+ * Authorization header so that Row Level Security policies are enforced for
+ * that specific user. SUPABASE_ANON_KEY is used as the API key so PostgREST
+ * evaluates the request in the `authenticated` role.
+ *
+ * When no userToken is present (unauthenticated fallback) the service-role key
+ * is used, which bypasses RLS. In practice this path should only be reached
+ * when REQUIRE_AUTH_FOR_PREFERENCES is false.
+ */
 async function supabaseFetch(
   config: { url: string; key: string },
   method: string,
   path: string,
   body?: unknown,
   extraHeaders?: Record<string, string>,
+  userToken?: string,
 ): Promise<Response> {
+  // Use the anon key as apikey when we have a user token so PostgREST applies
+  // RLS. Fall back to the service-role key for unauthenticated paths.
+  const anonKey = process.env.SUPABASE_ANON_KEY ?? config.key;
+  const apikey = userToken ? anonKey : config.key;
+  const authorization = userToken ? `Bearer ${userToken}` : `Bearer ${config.key}`;
+
   return fetch(`${config.url}/rest/v1/${path}`, {
     method,
     headers: {
-      apikey: config.key,
-      Authorization: `Bearer ${config.key}`,
+      apikey,
+      Authorization: authorization,
       'Content-Type': 'application/json',
       Accept: 'application/json',
       ...extraHeaders,
@@ -69,11 +88,15 @@ async function supabaseFetch(
 async function loadFromSupabase(
   config: { url: string; key: string },
   userId: string,
+  userToken?: string,
 ): Promise<StoredPreferences | null> {
   const resp = await supabaseFetch(
     config,
     'GET',
     `user_preferences?user_id=eq.${encodeURIComponent(userId)}&select=*`,
+    undefined,
+    undefined,
+    userToken,
   );
   if (!resp.ok) return null;
   const rows = (await resp.json()) as SupabasePrefsRow[];
@@ -94,6 +117,7 @@ async function saveToSupabase(
   config: { url: string; key: string },
   userId: string,
   data: StoredPreferences,
+  userToken?: string,
 ): Promise<boolean> {
   const row: SupabasePrefsRow = {
     user_id: userId,
@@ -109,6 +133,7 @@ async function saveToSupabase(
     'user_preferences?on_conflict=user_id',
     row,
     { Prefer: 'resolution=merge-duplicates' },
+    userToken,
   );
   return resp.ok || resp.status === 201;
 }
@@ -153,13 +178,21 @@ export default async function handler(req: any, res: any) {
   }
 
   const identity = authUser ? authUser.id : normalizeIpIdentity(req);
+
+  // Extract the raw bearer token so Supabase RLS can be enforced using the
+  // caller's own JWT rather than the service-role key.
+  const bearerToken =
+    (req.headers?.['authorization'] as string | undefined)
+      ?.replace(/^Bearer\s+/i, '')
+      .trim() || undefined;
+
   const db = supabaseConfig();
 
   if (req.method === 'GET') {
     let current: StoredPreferences;
     if (db) {
       try {
-        current = (await loadFromSupabase(db, identity)) ?? getMemoryStored(identity);
+        current = (await loadFromSupabase(db, identity, bearerToken)) ?? getMemoryStored(identity);
       } catch {
         current = getMemoryStored(identity);
       }
@@ -178,11 +211,10 @@ export default async function handler(req: any, res: any) {
   if (req.method === 'PUT') {
     const body = (req.body || {}) as PreferencesPayload;
 
-    // Load current values first so we can merge properly.
     let current: StoredPreferences;
     if (db) {
       try {
-        current = (await loadFromSupabase(db, identity)) ?? getMemoryStored(identity);
+        current = (await loadFromSupabase(db, identity, bearerToken)) ?? getMemoryStored(identity);
       } catch {
         current = getMemoryStored(identity);
       }
@@ -201,11 +233,10 @@ export default async function handler(req: any, res: any) {
       updatedAt: new Date().toISOString(),
     };
 
-    // Persist — Supabase first, memory fallback always updated.
     memoryStore.set(identity, next);
     if (db) {
       try {
-        await saveToSupabase(db, identity, next);
+        await saveToSupabase(db, identity, next, bearerToken);
       } catch {
         // Memory store already has the latest; Supabase will sync next time.
       }


### PR DESCRIPTION
- api/_lib/auth.ts: remove legacy x-user-id header fallback. Any request without a valid Bearer token now returns null (→ 401). This closes a spoofing vector where any caller could impersonate an arbitrary user by setting the x-user-id header.

- api/preferences.ts: pass the caller's JWT through to all Supabase REST API calls instead of always using the service-role key. Uses SUPABASE_ANON_KEY as apikey when a user token is present so PostgREST evaluates requests in the 'authenticated' role and Row Level Security policies are applied. Service-role key is retained as fallback only for unauthenticated paths (when REQUIRE_AUTH_FOR_PREFERENCES=false).

Note: add SUPABASE_ANON_KEY to Vercel environment variables (same value as VITE_SUPABASE_ANON_KEY) for full RLS enforcement.