### PR TITLE
Change DEFAULT_PREFERENCES to Required<UserPreferences>

### DIFF
--- a/api/preferences.ts
+++ b/api/preferences.ts
@@ -17,7 +17,7 @@ type StoredPreferences = {
   updatedAt: string;
 };
 
-const DEFAULT_PREFERENCES: UserPreferences = {
+const DEFAULT_PREFERENCES: Required<UserPreferences> = {
   notifications: true,
   emailUpdates: false,
   autoSave: true,


### PR DESCRIPTION
Changes DEFAULT_PREFERENCES type from UserPreferences to Required<UserPreferences>.

Root cause: Vercel's serverless TypeScript compilation was silently aborting on TS2322 errors at lines 124-126 of api/preferences.ts, which prevented api/_lib/auth.ts from being emitted to the output bundle. Result: ERR_MODULE_NOT_FOUND at runtime on all /api/* routes.

This was a latent bug hidden by Vercel's build cache before the recent PR triggered a fresh build.