### PR TITLE
fix: add .js extensions to ESM imports in api/

### DIFF
--- a/api/auth/me.ts
+++ b/api/auth/me.ts
@@ -1,4 +1,4 @@
-import { extractUser } from '../_lib/auth';
+import { extractUser } from '../_lib/auth.js';
 
 export default async function handler(req: any, res: any) {
   const user = await extractUser(req);

--- a/api/llm/complete.ts
+++ b/api/llm/complete.ts
@@ -4,9 +4,9 @@ type RequestBody = {
   jsonMode?: boolean;
 };
 
-import { extractUser } from '../_lib/auth';
-import { checkAndConsumeRateLimit, inferTier } from '../_lib/rate-limit';
-import { recordUsageEvent } from '../_lib/usage-log';
+import { extractUser } from '../_lib/auth.js';
+import { checkAndConsumeRateLimit, inferTier } from '../_lib/rate-limit.js';
+import { recordUsageEvent } from '../_lib/usage-log.js';
 
 type ChatResponse = {
   choices?: Array<{ 

--- a/api/preferences.ts
+++ b/api/preferences.ts
@@ -1,4 +1,4 @@
-import { extractUser } from './_lib/auth';
+import { extractUser } from './_lib/auth.js';
 
 type UserPreferences = {
   notifications?: boolean;


### PR DESCRIPTION
Node's ESM resolver (package.json type: module) requires explicit file extensions on relative imports. Without .js, Node throws ERR_MODULE_NOT_FOUND at runtime, breaking all /api/* routes.

This fixes the 500 errors on /api/preferences, /api/auth/me, and /api/llm/complete.