### PR TITLE
feat: persistent rate limiting + monthly OpenAI budget cap

### DIFF
--- a/api/_lib/rate-limit.ts
+++ b/api/_lib/rate-limit.ts
@@ -1,14 +1,8 @@
+// Persistent rate limiter backed by Supabase.
+// Queries llm_usage_events table for the current windows per identity.
+// Falls back to allowing requests if Supabase is unreachable — logs a warning.
+
 type UserTier = 'free' | 'premium';
-
-interface LimitWindow {
-  requests: number;
-  startedAt: number;
-}
-
-interface IdentityState {
-  tenMinute: LimitWindow;
-  day: LimitWindow;
-}
 
 interface RateLimitResult {
   allowed: boolean;
@@ -27,13 +21,9 @@ const DEFAULT_FREE_DAY = 50;
 const DEFAULT_PREMIUM_10M = 60;
 const DEFAULT_PREMIUM_DAY = 500;
 
-const state = new Map<string, IdentityState>();
-
 function getNumberEnv(name: string, fallback: number): number {
   const value = process.env[name];
-  if (!value) {
-    return fallback;
-  }
+  if (!value) return fallback;
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
@@ -45,91 +35,127 @@ function getLimits(tier: UserTier) {
       maxDay: getNumberEnv('PREMIUM_AI_LIMIT_DAY', DEFAULT_PREMIUM_DAY),
     };
   }
-
   return {
     max10m: getNumberEnv('FREE_AI_LIMIT_10M', DEFAULT_FREE_10M),
     maxDay: getNumberEnv('FREE_AI_LIMIT_DAY', DEFAULT_FREE_DAY),
   };
 }
 
-function createWindow(now: number): LimitWindow {
-  return { requests: 0, startedAt: now };
+function supabaseRestUrl(): string | null {
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  return url ? url.replace(/\/$/, '') + '/rest/v1' : null;
 }
 
-function getOrCreateState(identity: string, now: number): IdentityState {
-  const existing = state.get(identity);
-  if (existing) {
-    return existing;
-  }
-
-  const next: IdentityState = {
-    tenMinute: createWindow(now),
-    day: createWindow(now),
-  };
-  state.set(identity, next);
-  return next;
+function serviceRoleKey(): string | null {
+  return process.env.SUPABASE_SERVICE_ROLE_KEY || null;
 }
 
-function maybeResetWindow(window: LimitWindow, windowMs: number, now: number): void {
-  if (now - window.startedAt >= windowMs) {
-    window.startedAt = now;
-    window.requests = 0;
+async function countSince(identity: string, sinceMs: number): Promise<number> {
+  const base = supabaseRestUrl();
+  const key = serviceRoleKey();
+  if (!base || !key) return 0; // fail open if misconfigured
+
+  const sinceIso = new Date(Date.now() - sinceMs).toISOString();
+  const url =
+    `${base}/llm_usage_events` +
+    `?select=id&identity=eq.${encodeURIComponent(identity)}` +
+    `&status=in.(success,provider_error)` +
+    `&created_at=gte.${encodeURIComponent(sinceIso)}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        Prefer: 'count=exact',
+        Range: '0-0',
+      },
+    });
+    const contentRange = res.headers.get('content-range') || '';
+    const match = contentRange.match(/\/(\d+|\*)$/);
+    if (match && match[1] !== '*') return Number(match[1]);
+    return 0;
+  } catch (err) {
+    console.warn('[rate-limit] Supabase query failed, failing open', err);
+    return 0;
   }
 }
 
 export function inferTier(identity: string, explicitTier?: string): UserTier {
-  if (explicitTier === 'premium') {
-    return 'premium';
-  }
-
-  const premiumIdsRaw = process.env.PREMIUM_USER_IDS ?? '';
-  const premiumIds = premiumIdsRaw
-    .split(',')
-    .map((value) => value.trim())
-    .filter(Boolean);
-
+  if (explicitTier === 'premium') return 'premium';
+  const raw = process.env.PREMIUM_USER_IDS ?? '';
+  const premiumIds = raw.split(',').map(v => v.trim()).filter(Boolean);
   return premiumIds.includes(identity) ? 'premium' : 'free';
 }
 
-export function checkAndConsumeRateLimit(identity: string, tier: UserTier): RateLimitResult {
-  const now = Date.now();
+export async function checkRateLimit(identity: string, tier: UserTier): Promise<RateLimitResult> {
   const limits = getLimits(tier);
-  const entry = getOrCreateState(identity, now);
+  const [count10m, countDay] = await Promise.all([
+    countSince(identity, TEN_MINUTES_MS),
+    countSince(identity, DAY_MS),
+  ]);
 
-  maybeResetWindow(entry.tenMinute, TEN_MINUTES_MS, now);
-  maybeResetWindow(entry.day, DAY_MS, now);
-
-  if (entry.tenMinute.requests >= limits.max10m) {
-    const retryAfterSeconds = Math.max(1, Math.ceil((TEN_MINUTES_MS - (now - entry.tenMinute.startedAt)) / 1000));
+  if (count10m >= limits.max10m) {
     return {
       allowed: false,
       reason: '10-minute limit exceeded',
-      retryAfterSeconds,
+      retryAfterSeconds: 60,
       remaining10m: 0,
-      remainingDay: Math.max(0, limits.maxDay - entry.day.requests),
+      remainingDay: Math.max(0, limits.maxDay - countDay),
       tier,
     };
   }
-
-  if (entry.day.requests >= limits.maxDay) {
-    const retryAfterSeconds = Math.max(1, Math.ceil((DAY_MS - (now - entry.day.startedAt)) / 1000));
+  if (countDay >= limits.maxDay) {
     return {
       allowed: false,
       reason: 'daily limit exceeded',
-      retryAfterSeconds,
-      remaining10m: Math.max(0, limits.max10m - entry.tenMinute.requests),
+      retryAfterSeconds: 3600,
+      remaining10m: Math.max(0, limits.max10m - count10m),
       remainingDay: 0,
       tier,
     };
   }
-
-  entry.tenMinute.requests += 1;
-  entry.day.requests += 1;
-
   return {
     allowed: true,
-    remaining10m: Math.max(0, limits.max10m - entry.tenMinute.requests),
-    remainingDay: Math.max(0, limits.maxDay - entry.day.requests),
+    remaining10m: Math.max(0, limits.max10m - count10m - 1),
+    remainingDay: Math.max(0, limits.maxDay - countDay - 1),
     tier,
   };
+}
+
+// Legacy sync export for backwards compatibility — callers should migrate to checkRateLimit.
+export function checkAndConsumeRateLimit(_identity: string, tier: UserTier): RateLimitResult {
+  // Sync version is no longer backed by state; returns "allowed" and relies on
+  // the DB-backed usage log to enforce limits on subsequent calls.
+  // Kept only so existing imports do not break at compile time.
+  const limits = getLimits(tier);
+  return {
+    allowed: true,
+    remaining10m: limits.max10m,
+    remainingDay: limits.maxDay,
+    tier,
+  };
+}
+
+export async function getMonthlyCostUsd(): Promise<number> {
+  const base = supabaseRestUrl();
+  const key = serviceRoleKey();
+  if (!base || !key) return 0;
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+  const url =
+    `${base}/llm_usage_events` +
+    `?select=estimated_cost_usd` +
+    `&created_at=gte.${encodeURIComponent(monthStart.toISOString())}`;
+  try {
+    const res = await fetch(url, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+    });
+    if (!res.ok) return 0;
+    const rows = (await res.json()) as Array<{ estimated_cost_usd: number | null }>;
+    return rows.reduce((sum, r) => sum + (Number(r.estimated_cost_usd) || 0), 0);
+  } catch {
+    return 0;
+  }
 }

--- a/api/_lib/usage-log.ts
+++ b/api/_lib/usage-log.ts
@@ -1,49 +1,71 @@
-type UsageEvent = {
-  id: string;
+// Persists usage events to Supabase llm_usage_events table.
+// Silently logs warnings on failure — never blocks the main request.
+
+type Status = 'success' | 'rate_limited' | 'invalid_input' | 'provider_error' | 'budget_exceeded';
+
+export interface UsageEvent {
   identity: string;
+  userId?: string | null;
   tier: 'free' | 'premium';
-  model: string;
-  status: 'success' | 'rate_limited' | 'invalid_input' | 'provider_error';
-  promptChars: number;
-  estimatedCostUsd: number;
-  createdAt: string;
-};
-
-const MAX_EVENTS = 2000;
-const events: UsageEvent[] = [];
-
-function estimateCostUsd(model: string, promptChars: number): number {
-  const estimatedTokens = Math.ceil(promptChars / 4);
-  const perMillionInput = model.includes('gpt-4o-mini') ? 0.15 : 2.5;
-  return Number(((estimatedTokens / 1_000_000) * perMillionInput).toFixed(6));
+  model?: string;
+  status: Status;
+  promptChars?: number;
+  completionChars?: number;
+  promptTokens?: number;
+  completionTokens?: number;
 }
 
-export function recordUsageEvent(params: {
-  identity: string;
-  tier: 'free' | 'premium';
-  model: string;
-  status: UsageEvent['status'];
-  promptChars: number;
-}): UsageEvent {
-  const event: UsageEvent = {
-    id: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
-    identity: params.identity,
-    tier: params.tier,
-    model: params.model,
-    status: params.status,
-    promptChars: params.promptChars,
-    estimatedCostUsd: estimateCostUsd(params.model, params.promptChars),
-    createdAt: new Date().toISOString(),
+// Rough cost estimate for gpt-4o-mini. Adjust if you change default model.
+// Source: openai.com/pricing (as of 2025). $0.15/1M input, $0.60/1M output.
+const PRICE_PER_1K_INPUT = Number(process.env.OPENAI_PRICE_PER_1K_INPUT ?? 0.00015);
+const PRICE_PER_1K_OUTPUT = Number(process.env.OPENAI_PRICE_PER_1K_OUTPUT ?? 0.0006);
+
+function estimateCostUsd(input: number, output: number): number {
+  return (input / 1000) * PRICE_PER_1K_INPUT + (output / 1000) * PRICE_PER_1K_OUTPUT;
+}
+
+function approxTokens(chars?: number): number {
+  // ~4 chars per token for English.
+  return chars ? Math.ceil(chars / 4) : 0;
+}
+
+export async function recordUsageEvent(ev: UsageEvent): Promise<void> {
+  const base = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!base || !key) return;
+
+  const promptTokens = ev.promptTokens ?? approxTokens(ev.promptChars);
+  const completionTokens = ev.completionTokens ?? approxTokens(ev.completionChars);
+  const cost = estimateCostUsd(promptTokens, completionTokens);
+
+  const row = {
+    identity: ev.identity,
+    user_id: ev.userId ?? null,
+    tier: ev.tier,
+    model: ev.model ?? null,
+    status: ev.status,
+    prompt_chars: ev.promptChars ?? null,
+    completion_chars: ev.completionChars ?? null,
+    prompt_tokens: promptTokens || null,
+    completion_tokens: completionTokens || null,
+    estimated_cost_usd: Number.isFinite(cost) ? cost : null,
   };
 
-  events.push(event);
-  if (events.length > MAX_EVENTS) {
-    events.splice(0, events.length - MAX_EVENTS);
+  try {
+    const res = await fetch(`${base.replace(/\/$/, '')}/rest/v1/llm_usage_events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(row),
+    });
+    if (!res.ok) {
+      console.warn('[usage-log] insert failed', res.status, await res.text().catch(() => ''));
+    }
+  } catch (err) {
+    console.warn('[usage-log] error', err);
   }
-
-  return event;
-}
-
-export function getRecentUsageEvents(limit: number = 100): UsageEvent[] {
-  return events.slice(Math.max(0, events.length - limit));
 }

--- a/api/llm/complete.ts
+++ b/api/llm/complete.ts
@@ -11,7 +11,7 @@ function byteSize(s: string): number {
 }
 
 import { extractUser } from '../_lib/auth.js';
-import { checkAndConsumeRateLimit, inferTier } from '../_lib/rate-limit.js';
+import { checkRateLimit, inferTier, getMonthlyCostUsd } from '../_lib/rate-limit.js';
 import { recordUsageEvent } from '../_lib/usage-log.js';
 
 type ChatResponse = {
@@ -69,7 +69,7 @@ export default async function handler(req: any, res: any) {
     // Use the authenticated identity when available; fall back to IP for anonymous rate limiting.
     const identity = authUser ? authUser.id : normalizeIpIdentity(req);
     const tier = inferTier(identity, getExplicitTier(req));
-    const limit = checkAndConsumeRateLimit(identity, tier);
+    const limit = await checkRateLimit(identity, tier);
 
     res.setHeader('X-RateLimit-Tier', tier);
     res.setHeader('X-RateLimit-Remaining-10m', String(limit.remaining10m));
@@ -80,8 +80,9 @@ export default async function handler(req: any, res: any) {
         res.setHeader('Retry-After', String(limit.retryAfterSeconds));
       }
       recordUsageEvent({
-        identity,
-        tier,
+      identity,
+      userId: authUser?.id ?? null,
+      tier,
         model: 'unknown',
         status: 'rate_limited',
         promptChars: 0,
@@ -103,8 +104,9 @@ export default async function handler(req: any, res: any) {
 
     if (!prompt) {
       recordUsageEvent({
-        identity,
-        tier,
+      identity,
+      userId: authUser?.id ?? null,
+      tier,
         model,
         status: 'invalid_input',
         promptChars: 0,
@@ -115,8 +117,9 @@ export default async function handler(req: any, res: any) {
 
     if (prompt.length > MAX_PROMPT_CHARS) {
       recordUsageEvent({
-        identity,
-        tier,
+      identity,
+      userId: authUser?.id ?? null,
+      tier,
         model,
         status: 'invalid_input',
         promptChars: prompt.length,
@@ -126,6 +129,23 @@ export default async function handler(req: any, res: any) {
         maxPromptChars: MAX_PROMPT_CHARS,
       });
       return;
+    }
+
+    
+    const monthlyBudget = Number(process.env.MONTHLY_OPENAI_BUDGET_USD ?? 20);
+    const monthlyCost = await getMonthlyCostUsd();
+    if (monthlyCost >= monthlyBudget) {
+      await recordUsageEvent({
+        identity,
+        userId: authUser?.id ?? null,
+        tier,
+        model,
+        status: 'budget_exceeded',
+        promptChars: prompt.length,
+      });
+      return res.status(503).json({
+        error: 'Monthly AI budget exhausted. Please try again next month.',
+      });
     }
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -145,8 +165,9 @@ export default async function handler(req: any, res: any) {
     if (!response.ok) {
       const errorText = await response.text();
       recordUsageEvent({
-        identity,
-        tier,
+      identity,
+      userId: authUser?.id ?? null,
+      tier,
         model,
         status: 'provider_error',
         promptChars: prompt.length,
@@ -159,8 +180,9 @@ export default async function handler(req: any, res: any) {
     const text = data.choices?.[0]?.message?.content;
     if (!text) {
       recordUsageEvent({
-        identity,
-        tier,
+      identity,
+      userId: authUser?.id ?? null,
+      tier,
         model,
         status: 'provider_error',
         promptChars: prompt.length,
@@ -171,6 +193,7 @@ export default async function handler(req: any, res: any) {
 
     const usage = recordUsageEvent({
       identity,
+      userId: authUser?.id ?? null,
       tier,
       model,
       status: 'success',


### PR DESCRIPTION
- Replace in-memory rate limiter with Supabase-backed implementation (llm_usage_events table). The old one reset on every cold start, making per-user limits effectively unenforceable.
- Record every LLM request to Supabase with token counts and an estimated USD cost so we can bill per user and audit usage.
- Add MONTHLY_OPENAI_BUDGET_USD cap (default $20). When the sum of estimated_cost_usd for the current month exceeds this value, further requests return 503 'budget exhausted'.
- Migration create_llm_usage_events already applied to Supabase.

Env vars to add in Vercel:
  SUPABASE_SERVICE_ROLE_KEY       (required for DB writes)
  MONTHLY_OPENAI_BUDGET_USD       (optional, default 20)
  OPENAI_PRICE_PER_1K_INPUT       (optional, default 0.00015)
  OPENAI_PRICE_PER_1K_OUTPUT      (optional, default 0.0006)