### PR TITLE
Align Supabase env names + rebuild auth UI (recovery, magic link)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ pids
 .devcontainer/
 
 .spark-workbench-id
+.vercel
+.env*.local

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Copy `.env.example` to `.env` and fill in the required values:
 | Variable | Required | Description |
 |---|---|---|
 | `OPENAI_API_KEY` | ✅ Yes | Your OpenAI API key for AI story generation |
-| `SUPABASE_URL` | When using Supabase auth | Your Supabase project URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | When using Supabase auth | Service role key for server-side JWT validation |
-| `VITE_SUPABASE_URL` | When using Supabase auth | Supabase URL (exposed to browser) |
-| `VITE_SUPABASE_ANON_KEY` | When using Supabase auth | Supabase anon key (exposed to browser) |
+| `SUPABASE_URL` *or* `NEXT_PUBLIC_SUPABASE_URL` | When using Supabase auth | Supabase project URL (server-side) |
+| `SUPABASE_SERVICE_ROLE_KEY` *or* `SUPABASE_SECRET_KEY` | When using Supabase auth | Server-side key for JWT validation |
+| `VITE_SUPABASE_URL` *or* `NEXT_PUBLIC_SUPABASE_URL` | When using Supabase auth | Supabase URL (exposed to browser) |
+| `VITE_SUPABASE_ANON_KEY` *or* `NEXT_PUBLIC_SUPABASE_ANON_KEY` | When using Supabase auth | Supabase anon key (exposed to browser) |
 | `FREE_AI_LIMIT_10M` | No | Free-tier max requests per 10 min (default: 10) |
 | `FREE_AI_LIMIT_DAY` | No | Free-tier max requests per day (default: 50) |
 | `PREMIUM_AI_LIMIT_10M` | No | Premium max requests per 10 min (default: 60) |
@@ -103,8 +103,7 @@ Copy `.env.example` to `.env` and fill in the required values:
 2. **Connect your repo** in the [Vercel dashboard](https://vercel.com/new).
 3. **Set environment variables** in *Project → Settings → Environment Variables*:
    - `OPENAI_API_KEY` — required for AI features
-   - `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` — if using Supabase auth
-   - `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` — if using Supabase on the frontend
+   - Supabase: either install the **Vercel ↔ Supabase marketplace integration** (auto-injects `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SECRET_KEY`, etc.) *or* set `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` + `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` manually. The app reads either naming convention.
    - Rate-limit variables as needed
 4. **Deploy** — Vercel uses `vercel.json` for build config (`tsc -b && vite build`).
 

--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -2,9 +2,11 @@
 //
 // Validates user identity from the Authorization: Bearer header.
 //
-// To enable full Supabase JWT verification, set the SUPABASE_URL and
-// SUPABASE_SERVICE_ROLE_KEY environment variables. The helper will then verify
-// the JWT via Supabase and extract the canonical user ID from the token payload.
+// To enable full Supabase JWT verification, set the Supabase URL and a
+// server-side key. Supports both the legacy manual names (SUPABASE_URL,
+// SUPABASE_SERVICE_ROLE_KEY) and the names injected by the Vercel ↔ Supabase
+// marketplace integration (NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SECRET_KEY).
+// The first available pair wins.
 
 export interface AuthenticatedUser {
   id: string;
@@ -17,9 +19,9 @@ function normalizeIdentity(rawIdentity: string): string {
 /**
  * Extracts a verified user identity from the request.
  *
- * Reads the Authorization: Bearer <token> header. When SUPABASE_URL and
- * SUPABASE_SERVICE_ROLE_KEY are configured the token is verified via Supabase
- * and the canonical user ID is returned.
+ * Reads the Authorization: Bearer <token> header. When a Supabase URL and
+ * server-side key are configured the token is verified via Supabase and the
+ * canonical user ID is returned.
  *
  * Returns null when no valid identity can be determined.
  */
@@ -28,8 +30,10 @@ export async function extractUser(req: any): Promise<AuthenticatedUser | null> {
   if (authHeader?.startsWith('Bearer ')) {
     const token = authHeader.slice(7).trim();
     if (token.length > 0) {
-      const supabaseUrl = process.env.SUPABASE_URL;
-      const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+      const supabaseUrl =
+        process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const serviceRoleKey =
+        process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SECRET_KEY;
       if (supabaseUrl && serviceRoleKey) {
         try {
           const resp = await fetch(`${supabaseUrl}/auth/v1/user`, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "spark-template",
+  "name": "memory-journal",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "spark-template",
+      "name": "memory-journal",
       "version": "0.0.0",
       "dependencies": {
         "@github/spark": ">=0.43.1 <1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ const EntryEditScreen = lazy(() =>
 );
 
 function AppContent() {
-  const { session, loading: authLoading } = useAuth();
+  const { session, loading: authLoading, isPasswordRecovery } = useAuth();
   const [currentView, setCurrentView] = useState<AppView>({ type: 'home' });
   const { isDarkMode, isNightTime, themeMode, setThemeMode } = useTheme();
   const isMobile = useIsMobile();
@@ -340,7 +340,7 @@ function AppContent() {
         </div>
       );
     }
-    if (!session) {
+    if (!session || isPasswordRecovery) {
       return <AuthScreen />;
     }
   }

--- a/src/components/screens/AuthScreen.tsx
+++ b/src/components/screens/AuthScreen.tsx
@@ -1,135 +1,420 @@
-import { useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
-import { DreamyBackground } from '../DreamyBackground';
 import { useTheme } from '../../contexts/ThemeContext';
+import { DreamyBackground } from '../DreamyBackground';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+import { Label } from '../ui/label';
+import { friendlyAuthError } from '../../lib/auth-errors';
+import { ArrowLeft, CheckCircle2, Mail } from 'lucide-react';
 
-type AuthMode = 'login' | 'signup';
+type AuthMode =
+  | 'signin'
+  | 'signup'
+  | 'forgot'
+  | 'magic-link'
+  | 'reset'
+  | 'sent-verify'
+  | 'sent-magic'
+  | 'sent-recovery';
+
+interface Feedback {
+  message: string;
+  hint?: string;
+}
 
 export function AuthScreen() {
-  const { signIn, signUp } = useAuth();
+  const {
+    signIn,
+    signUp,
+    signInWithMagicLink,
+    resetPassword,
+    updatePassword,
+    isPasswordRecovery,
+  } = useAuth();
   const { isDarkMode } = useTheme();
-  const [mode, setMode] = useState<AuthMode>('login');
+
+  const [mode, setMode] = useState<AuthMode>('signin');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [info, setInfo] = useState<string | null>(null);
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [error, setError] = useState<Feedback | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  // When the user arrives via a recovery link, Supabase emits
+  // PASSWORD_RECOVERY on the auth-state subscription. Switch to the reset
+  // mode so the user can set a new password.
+  useEffect(() => {
+    if (isPasswordRecovery) {
+      setMode('reset');
+      setError(null);
+    }
+  }, [isPasswordRecovery]);
+
+  const resetFormState = () => {
+    setError(null);
+    setPassword('');
+    setPasswordConfirm('');
+  };
+
+  const switchMode = (next: AuthMode) => {
+    setMode(next);
+    resetFormState();
+  };
+
+  // --- submit handlers ---------------------------------------------------
+
+  const handleSignIn = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
-    setInfo(null);
     setLoading(true);
-
-    if (mode === 'login') {
-      const { error: err } = await signIn(email, password);
-      if (err) {
-        setError(err.message);
-      }
-    } else {
-      const { error: err } = await signUp(email, password);
-      if (err) {
-        setError(err.message);
-      } else {
-        setInfo('Account created! You can now sign in.');
-        setMode('login');
-        setPassword('');
-      }
-    }
+    const { error: err } = await signIn(email, password);
     setLoading(false);
+    if (err) setError(friendlyAuthError(err));
   };
+
+  const handleSignUp = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password !== passwordConfirm) {
+      setError({ message: "Those passwords don't match." });
+      return;
+    }
+    setLoading(true);
+    const { error: err } = await signUp(email, password);
+    setLoading(false);
+    if (err) {
+      setError(friendlyAuthError(err));
+      return;
+    }
+    setMode('sent-verify');
+  };
+
+  const handleForgot = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const { error: err } = await resetPassword(email);
+    setLoading(false);
+    if (err) {
+      setError(friendlyAuthError(err));
+      return;
+    }
+    setMode('sent-recovery');
+  };
+
+  const handleMagicLink = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const { error: err } = await signInWithMagicLink(email);
+    setLoading(false);
+    if (err) {
+      setError(friendlyAuthError(err));
+      return;
+    }
+    setMode('sent-magic');
+  };
+
+  const handleReset = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password !== passwordConfirm) {
+      setError({ message: "Those passwords don't match." });
+      return;
+    }
+    setLoading(true);
+    const { error: err } = await updatePassword(password);
+    setLoading(false);
+    if (err) {
+      setError(friendlyAuthError(err));
+      return;
+    }
+    // Success: AuthContext clears isPasswordRecovery, the App then renders
+    // the main UI because the session is still active.
+  };
+
+  // --- rendering ---------------------------------------------------------
+
+  const header = (() => {
+    switch (mode) {
+      case 'signin':
+        return { title: 'Welcome back', subtitle: 'Sign in to your journal.' };
+      case 'signup':
+        return { title: 'Create your journal', subtitle: 'Start holding memories tight.' };
+      case 'forgot':
+        return {
+          title: 'Reset your password',
+          subtitle: "Enter your email and we'll send a recovery link.",
+        };
+      case 'magic-link':
+        return {
+          title: 'Sign in with a link',
+          subtitle: "We'll email you a one-time link — no password needed.",
+        };
+      case 'reset':
+        return { title: 'Choose a new password', subtitle: 'Pick something you can remember.' };
+      case 'sent-verify':
+        return { title: 'Check your inbox', subtitle: `We sent a verification link to ${email}.` };
+      case 'sent-magic':
+        return { title: 'Check your inbox', subtitle: `We sent a sign-in link to ${email}.` };
+      case 'sent-recovery':
+        return { title: 'Check your inbox', subtitle: `We sent a recovery link to ${email}.` };
+    }
+  })();
 
   return (
     <div className="min-h-screen relative flex items-center justify-center">
       <DreamyBackground isDarkMode={isDarkMode} />
       <div className="relative z-10 w-full max-w-sm px-6">
-        {/* Logo / Brand */}
         <div className="mb-8 text-center">
           <h1 className="text-3xl font-bold tracking-tight">Memory Journal</h1>
           <p className="mt-1 text-sm opacity-60">Hold them tight</p>
         </div>
 
-        {/* Card */}
         <div className="rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md p-8 shadow-xl">
-          <h2 className="text-xl font-semibold mb-6">
-            {mode === 'login' ? 'Sign in to your account' : 'Create an account'}
-          </h2>
-
-          {info && (
-            <div className="mb-4 rounded-lg bg-green-500/10 border border-green-500/30 px-4 py-3 text-sm text-green-700 dark:text-green-300">
-              {info}
-            </div>
-          )}
-
-          {error && (
-            <div className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3 text-sm text-red-700 dark:text-red-300">
-              {error}
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label htmlFor="email" className="block text-sm font-medium mb-1 opacity-80">
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                autoComplete="email"
-                required
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm placeholder:opacity-40 focus:outline-none focus:ring-2 focus:ring-primary/50"
-                placeholder="you@example.com"
-              />
-            </div>
-
-            <div>
-              <label htmlFor="password" className="block text-sm font-medium mb-1 opacity-80">
-                Password
-              </label>
-              <input
-                id="password"
-                type="password"
-                autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
-                required
-                minLength={6}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm placeholder:opacity-40 focus:outline-none focus:ring-2 focus:ring-primary/50"
-                placeholder={mode === 'login' ? '••••••••' : 'Min. 6 characters'}
-              />
-            </div>
-
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
-            >
-              {loading
-                ? 'Please wait…'
-                : mode === 'login'
-                  ? 'Sign in'
-                  : 'Create account'}
-            </button>
-          </form>
-
-          <p className="mt-6 text-center text-sm opacity-60">
-            {mode === 'login' ? "Don't have an account?" : 'Already have an account?'}{' '}
+          {/* Back arrow for sub-flows */}
+          {(mode === 'forgot' ||
+            mode === 'magic-link' ||
+            mode === 'sent-verify' ||
+            mode === 'sent-magic' ||
+            mode === 'sent-recovery') && (
             <button
               type="button"
-              onClick={() => {
-                setMode(mode === 'login' ? 'signup' : 'login');
-                setError(null);
-                setInfo(null);
-              }}
-              className="font-medium underline underline-offset-2 hover:opacity-80"
+              onClick={() => switchMode('signin')}
+              className="mb-4 inline-flex items-center gap-1 text-sm opacity-70 hover:opacity-100"
             >
-              {mode === 'login' ? 'Sign up' : 'Sign in'}
+              <ArrowLeft className="size-3.5" />
+              Back to sign in
             </button>
-          </p>
+          )}
+
+          <div className="mb-6">
+            <h2 className="text-xl font-semibold">{header.title}</h2>
+            <p className="mt-1 text-sm opacity-60">{header.subtitle}</p>
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3 text-sm text-red-700 dark:text-red-300"
+            >
+              <p className="font-medium">{error.message}</p>
+              {error.hint && <p className="mt-1 opacity-80">{error.hint}</p>}
+            </div>
+          )}
+
+          {/* --- Sign in --------------------------------------------------- */}
+          {mode === 'signin' && (
+            <form onSubmit={handleSignIn} className="space-y-4">
+              <EmailField value={email} onChange={setEmail} />
+              <div>
+                <div className="flex items-baseline justify-between mb-1">
+                  <Label htmlFor="password" className="opacity-80">
+                    Password
+                  </Label>
+                  <button
+                    type="button"
+                    onClick={() => switchMode('forgot')}
+                    className="text-xs opacity-70 hover:opacity-100 underline-offset-2 hover:underline"
+                  >
+                    Forgot?
+                  </button>
+                </div>
+                <Input
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </div>
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? 'Signing in…' : 'Sign in'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => switchMode('magic-link')}
+              >
+                <Mail className="size-4" />
+                Email me a sign-in link
+              </Button>
+              <p className="pt-2 text-center text-sm opacity-70">
+                New here?{' '}
+                <button
+                  type="button"
+                  onClick={() => switchMode('signup')}
+                  className="font-medium underline underline-offset-2 hover:opacity-80"
+                >
+                  Create an account
+                </button>
+              </p>
+            </form>
+          )}
+
+          {/* --- Sign up --------------------------------------------------- */}
+          {mode === 'signup' && (
+            <form onSubmit={handleSignUp} className="space-y-4">
+              <EmailField value={email} onChange={setEmail} />
+              <div>
+                <Label htmlFor="password" className="opacity-80 mb-1 block">
+                  Password
+                </Label>
+                <Input
+                  id="password"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                  minLength={6}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Min. 6 characters"
+                />
+              </div>
+              <div>
+                <Label htmlFor="password-confirm" className="opacity-80 mb-1 block">
+                  Confirm password
+                </Label>
+                <Input
+                  id="password-confirm"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                  minLength={6}
+                  value={passwordConfirm}
+                  onChange={(e) => setPasswordConfirm(e.target.value)}
+                />
+              </div>
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? 'Creating account…' : 'Create account'}
+              </Button>
+              <p className="pt-2 text-center text-sm opacity-70">
+                Already have an account?{' '}
+                <button
+                  type="button"
+                  onClick={() => switchMode('signin')}
+                  className="font-medium underline underline-offset-2 hover:opacity-80"
+                >
+                  Sign in
+                </button>
+              </p>
+            </form>
+          )}
+
+          {/* --- Forgot password ------------------------------------------ */}
+          {mode === 'forgot' && (
+            <form onSubmit={handleForgot} className="space-y-4">
+              <EmailField value={email} onChange={setEmail} />
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? 'Sending…' : 'Send recovery link'}
+              </Button>
+            </form>
+          )}
+
+          {/* --- Magic link ----------------------------------------------- */}
+          {mode === 'magic-link' && (
+            <form onSubmit={handleMagicLink} className="space-y-4">
+              <EmailField value={email} onChange={setEmail} />
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? 'Sending…' : 'Email me a sign-in link'}
+              </Button>
+            </form>
+          )}
+
+          {/* --- Reset password ------------------------------------------- */}
+          {mode === 'reset' && (
+            <form onSubmit={handleReset} className="space-y-4">
+              <div>
+                <Label htmlFor="new-password" className="opacity-80 mb-1 block">
+                  New password
+                </Label>
+                <Input
+                  id="new-password"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                  minLength={6}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Min. 6 characters"
+                />
+              </div>
+              <div>
+                <Label htmlFor="new-password-confirm" className="opacity-80 mb-1 block">
+                  Confirm new password
+                </Label>
+                <Input
+                  id="new-password-confirm"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                  minLength={6}
+                  value={passwordConfirm}
+                  onChange={(e) => setPasswordConfirm(e.target.value)}
+                />
+              </div>
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? 'Updating…' : 'Update password'}
+              </Button>
+            </form>
+          )}
+
+          {/* --- "Check your inbox" states -------------------------------- */}
+          {(mode === 'sent-verify' || mode === 'sent-magic' || mode === 'sent-recovery') && (
+            <div className="space-y-4 text-sm">
+              <div className="flex items-start gap-3 rounded-lg bg-green-500/10 border border-green-500/30 px-4 py-3 text-green-700 dark:text-green-300">
+                <CheckCircle2 className="size-5 shrink-0 mt-0.5" />
+                <div>
+                  <p className="font-medium">Link sent.</p>
+                  <p className="opacity-80">
+                    Click the link in the email to{' '}
+                    {mode === 'sent-verify'
+                      ? 'confirm your account'
+                      : mode === 'sent-magic'
+                        ? 'sign in'
+                        : 'choose a new password'}
+                    .
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs opacity-60">
+                Nothing arriving? Check your spam folder, or{' '}
+                <button
+                  type="button"
+                  onClick={() => switchMode(mode === 'sent-magic' ? 'magic-link' : 'forgot')}
+                  className="underline underline-offset-2"
+                >
+                  try again
+                </button>
+                .
+              </p>
+            </div>
+          )}
         </div>
       </div>
+    </div>
+  );
+}
+
+// Shared email input — same field appears in most modes.
+function EmailField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <Label htmlFor="email" className="opacity-80 mb-1 block">
+        Email
+      </Label>
+      <Input
+        id="email"
+        type="email"
+        autoComplete="email"
+        required
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="you@example.com"
+      />
     </div>
   );
 }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,8 +11,17 @@ interface AuthState {
 interface AuthActions {
   signUp: (email: string, password: string) => Promise<{ error: AuthError | null }>;
   signIn: (email: string, password: string) => Promise<{ error: AuthError | null }>;
+  signInWithMagicLink: (email: string) => Promise<{ error: AuthError | null }>;
+  resetPassword: (email: string) => Promise<{ error: AuthError | null }>;
+  updatePassword: (password: string) => Promise<{ error: AuthError | null }>;
   signOut: () => Promise<void>;
   getToken: () => string | null;
+  /**
+   * True when the current session was initiated by clicking a password
+   * recovery link. Consumers (e.g. the AuthScreen) use this to prompt the
+   * user to set a new password.
+   */
+  isPasswordRecovery: boolean;
 }
 
 type AuthContextValue = AuthState & AuthActions;
@@ -23,6 +32,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isPasswordRecovery, setIsPasswordRecovery] = useState(false);
 
   useEffect(() => {
     if (!supabase) {
@@ -38,10 +48,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     });
 
     // Subscribe to future auth state changes.
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, s) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, s) => {
       setSession(s);
       setUser(s?.user ?? null);
       setLoading(false);
+      if (event === 'PASSWORD_RECOVERY') {
+        setIsPasswordRecovery(true);
+      }
     });
 
     return () => subscription.unsubscribe();
@@ -52,7 +65,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const err = new Error('Supabase is not configured') as AuthError;
       return { error: err };
     }
-    const { error } = await supabase.auth.signUp({ email, password });
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: window.location.origin },
+    });
     return { error };
   }, []);
 
@@ -65,9 +82,45 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { error };
   }, []);
 
+  const signInWithMagicLink = useCallback(async (email: string) => {
+    if (!supabase) {
+      const err = new Error('Supabase is not configured') as AuthError;
+      return { error: err };
+    }
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.origin },
+    });
+    return { error };
+  }, []);
+
+  const resetPassword = useCallback(async (email: string) => {
+    if (!supabase) {
+      const err = new Error('Supabase is not configured') as AuthError;
+      return { error: err };
+    }
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: window.location.origin,
+    });
+    return { error };
+  }, []);
+
+  const updatePassword = useCallback(async (password: string) => {
+    if (!supabase) {
+      const err = new Error('Supabase is not configured') as AuthError;
+      return { error: err };
+    }
+    const { error } = await supabase.auth.updateUser({ password });
+    if (!error) {
+      setIsPasswordRecovery(false);
+    }
+    return { error };
+  }, []);
+
   const signOut = useCallback(async () => {
     if (!supabase) return;
     await supabase.auth.signOut();
+    setIsPasswordRecovery(false);
   }, []);
 
   // getToken reads the access_token from React state that is already loaded
@@ -77,7 +130,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [session]);
 
   return (
-    <AuthContext.Provider value={{ session, user, loading, signUp, signIn, signOut, getToken }}>
+    <AuthContext.Provider
+      value={{
+        session,
+        user,
+        loading,
+        signUp,
+        signIn,
+        signInWithMagicLink,
+        resetPassword,
+        updatePassword,
+        signOut,
+        getToken,
+        isPasswordRecovery,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -1,0 +1,58 @@
+// Maps Supabase AuthError messages / codes into short, human-friendly copy.
+// We deliberately keep this list small and fall back to the original message
+// so nothing is silently hidden.
+
+import type { AuthError } from '@supabase/supabase-js';
+
+type FriendlyError = { message: string; hint?: string };
+
+export function friendlyAuthError(err: AuthError | Error | null | undefined): FriendlyError | null {
+  if (!err) return null;
+  const raw = err.message ?? '';
+  const lower = raw.toLowerCase();
+
+  // Supabase exposes a numeric HTTP status on AuthError; 429 = rate limit.
+  const status = (err as AuthError).status;
+
+  if (lower.includes('invalid login credentials')) {
+    return { message: "That email and password don't match." };
+  }
+  if (lower.includes('email not confirmed')) {
+    return {
+      message: 'Please confirm your email first.',
+      hint: 'Check your inbox for a verification link.',
+    };
+  }
+  if (lower.includes('user already registered') || lower.includes('already been registered')) {
+    return {
+      message: 'An account with that email already exists.',
+      hint: 'Try signing in instead, or reset your password.',
+    };
+  }
+  if (lower.includes('password should be at least')) {
+    return { message: 'Password must be at least 6 characters.' };
+  }
+  if (lower.includes('unable to validate email') || lower.includes('invalid email')) {
+    return { message: "That email address doesn't look right." };
+  }
+  if (lower.includes('new password should be different')) {
+    return { message: 'Your new password must be different from the old one.' };
+  }
+  if (lower.includes('signup is disabled') || lower.includes('signups not allowed')) {
+    return { message: 'New sign-ups are currently disabled.' };
+  }
+  if (lower.includes('email rate limit') || status === 429) {
+    return {
+      message: 'Too many attempts — please wait a moment and try again.',
+    };
+  }
+  if (lower.includes('network') || lower.includes('failed to fetch')) {
+    return {
+      message: "Couldn't reach the server.",
+      hint: 'Check your internet connection and try again.',
+    };
+  }
+
+  // Fallback: surface the raw message so we never swallow unknown errors.
+  return { message: raw || 'Something went wrong. Please try again.' };
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,11 +1,20 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+// Support both the legacy VITE_* names (set manually) and the NEXT_PUBLIC_*
+// names injected by the Vercel ↔ Supabase marketplace integration. Whichever
+// is defined wins.
+const env = import.meta.env as Record<string, string | undefined>;
+const supabaseUrl = env.VITE_SUPABASE_URL ?? env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey =
+  env.VITE_SUPABASE_ANON_KEY ??
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn(
-    '[supabase] VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY is not set. ' +
+    '[supabase] No Supabase URL / anon key found. Set VITE_SUPABASE_URL + ' +
+      'VITE_SUPABASE_ANON_KEY, or use the Vercel ↔ Supabase integration ' +
+      '(NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY). ' +
       'Supabase auth will not be available.',
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ const projectRoot = process.env.PROJECT_ROOT || import.meta.dirname
 
 // https://vite.dev/config/
 export default defineConfig({
+  envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## What

Two related changes that make the Supabase login usable.

### 1. Env var alignment with the Vercel ↔ Supabase integration

The marketplace integration injects `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SECRET_KEY` / etc., while the app previously only read the manually-set `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` / `VITE_SUPABASE_*`. Rotating a Supabase key would silently leave the manual vars stale.

- `api/_lib/auth.ts`: fall back to `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SECRET_KEY`
- `vite.config.ts`: expose `NEXT_PUBLIC_*` to the client via `envPrefix`
- `src/lib/supabase.ts`: try `VITE_*` → `NEXT_PUBLIC_*` / publishable key
- README updated to document both naming conventions

Net effect: manual vars keep Preview/Dev working, integration-managed vars auto-flow to Production without code changes.

### 2. Rebuild the auth screen

Previously the `AuthScreen` only supported sign in / sign up — no way to recover a forgotten password, no email verification flow, raw Supabase error messages.

New flow has explicit modes on a single screen:

- **signin** — with *Forgot?* link + *Email me a sign-in link* (magic link) button
- **signup** — with password confirmation → "check your inbox" state
- **forgot** — sends a recovery email → "check your inbox"
- **reset** — auto-triggered by Supabase's `PASSWORD_RECOVERY` event; sets a new password
- **magic-link** — passwordless one-time sign-in
- **sent-*** — "check your inbox" confirmations with *try again* links

Also:
- `src/lib/auth-errors.ts` translates common Supabase errors into friendly copy (invalid credentials, rate limit, already registered, etc.)
- Use shared shadcn `Input` / `Button` / `Label` for consistency with the rest of the app
- `App.tsx` routes to `AuthScreen` when `isPasswordRecovery` is true, even if a session exists — otherwise recovery-link users would land on the main app instead of the reset form
- `AuthContext` exposes `resetPassword`, `updatePassword`, `signInWithMagicLink`, `isPasswordRecovery`

## Supabase config

Updated via the Management API:
- `Site URL` → `https://tightly.nl`
- `Redirect URLs` → `https://tightly.nl/**`, `http://localhost:5173/**`, plus existing Vercel preview wildcards (`https://memory-journal-*-magnusjeronos-projects.vercel.app/**`)

So recovery / magic-link emails now redirect correctly from both production and local dev.

## Verification

- `npx tsc -b` clean
- ESLint: only pre-existing warnings (unrelated `no-case-declarations` in `App.tsx` render switch, pre-existing `react-refresh` warning)
- Vercel will auto-create a Preview deployment for this branch