### PR TITLE
Persist journal data in Supabase (DB + Storage)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, lazy, Suspense, useCallback } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppView, NavigationTab } from './lib/types';
 import { DreamyBackground } from './components/DreamyBackground';
 import { BottomNav } from './components/navigation/BottomNav';
@@ -403,13 +404,24 @@ function AppContent() {
 function App() {
   return (
     <ThemeProvider>
-      <AuthProvider>
-        <LanguageProvider>
-          <AppContent />
-        </LanguageProvider>
-      </AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </AuthProvider>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
 
 export default App;

--- a/src/components/screens/EntryEditScreen.tsx
+++ b/src/components/screens/EntryEditScreen.tsx
@@ -48,6 +48,8 @@ import { useLocalStorage } from '@/hooks/use-local-storage';
 import { motion, AnimatePresence } from 'framer-motion';
 import { LogoHomeButton } from '@/components/LogoHomeButton';
 import { useLanguage } from '@/hooks/use-language.tsx';
+import { useAuth } from '@/contexts/AuthContext';
+import { uploadEntryPhoto, getSignedPhotoUrl } from '@/lib/photos';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 
@@ -99,9 +101,14 @@ export function EntryEditScreen({
 }: EntryEditScreenProps) {
   const { isDarkMode } = useTheme();
   const { t, language } = useLanguage();
+  const { user } = useAuth();
   const isMobile = useIsMobile();
   const isNewEntry = !entry;
   const prompt = promptId ? DEFAULT_PROMPTS.find(p => p.id === promptId) : null;
+
+  // Stable id for this editing session — used as the storage path segment for
+  // any photos uploaded before the entry row is saved.
+  const entryIdRef = useRef<string>(entry?.id ?? uuid());
 
   const [date, setDate] = useState<Date>(entry ? new Date(entry.date + 'T00:00:00') : new Date());
   const [title, setTitle] = useState(entry?.title_user || '');
@@ -323,26 +330,44 @@ export function EntryEditScreen({
   const processImageFiles = useCallback((files: File[]) => {
     const imageFiles = files.filter(file => file.type.startsWith('image/'));
     if (imageFiles.length === 0) return;
-    const newPhotos: Photo[] = [];
+    if (!user) {
+      toast.error('Please sign in to upload photos.');
+      return;
+    }
     const maxPhotos = 10 - photos.length;
     const filesToProcess = imageFiles.slice(0, maxPhotos);
-    filesToProcess.forEach(file => {
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        const url = event.target?.result as string;
-        newPhotos.push({
-          id: uuid(),
-          entry_id: '',
-          storage_url: url,
-          created_at: new Date().toISOString()
-        });
-        if (newPhotos.length === filesToProcess.length) {
-          setPhotos(prev => [...prev, ...newPhotos]);
+
+    void Promise.all(
+      filesToProcess.map(async (file) => {
+        try {
+          const { storage_path, width, height, bytes } = await uploadEntryPhoto(
+            user.id,
+            entryIdRef.current,
+            file,
+          );
+          const storage_url = await getSignedPhotoUrl(storage_path);
+          const photo: Photo = {
+            id: uuid(),
+            entry_id: entryIdRef.current,
+            storage_path,
+            storage_url,
+            width,
+            height,
+            bytes,
+            created_at: new Date().toISOString(),
+          };
+          return photo;
+        } catch (err) {
+          console.error('Photo upload failed', err);
+          toast.error(`Failed to upload ${file.name}`);
+          return null;
         }
-      };
-      reader.readAsDataURL(file);
+      }),
+    ).then((results) => {
+      const uploaded = results.filter((p): p is Photo => p !== null);
+      if (uploaded.length) setPhotos(prev => [...prev, ...uploaded]);
     });
-  }, [photos.length]);
+  }, [photos.length, user]);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -476,7 +501,7 @@ export function EntryEditScreen({
       return;
     }
 
-    const entryId = entry?.id || uuid();
+    const entryId = entry?.id || entryIdRef.current;
     const now = new Date().toISOString();
     
     const savedEntry: Entry = {

--- a/src/hooks/use-journal-data.ts
+++ b/src/hooks/use-journal-data.ts
@@ -1,206 +1,256 @@
-import { useLocalStorage } from './use-local-storage';
-import { Entry, Chapter, Book } from '@/lib/types';
-import { useEffect } from 'react';
-import { v4 as uuid } from 'uuid';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/lib/supabase';
+import { Entry, Chapter, Book } from '@/lib/types';
+import * as db from '@/lib/db';
 
-// Starter content
-const createStarterChapters = (): Chapter[] => {
-  const now = new Date().toISOString();
-  return [
-    {
-      id: uuid(),
-      name: 'Growing Up',
-      description: 'Childhood and family memories',
-      color: 'oklch(0.75 0.18 75)', // amber
-      icon: 'house',
-      is_pinned: false,
-      is_archived: false,
-      order: 0,
-      created_at: now,
-      updated_at: now,
-    },
-    {
-      id: uuid(),
-      name: 'Adventures',
-      description: 'Travel and experiences',
-      color: 'oklch(0.65 0.17 160)', // emerald
-      icon: 'airplane',
-      is_pinned: false,
-      is_archived: false,
-      order: 1,
-      created_at: now,
-      updated_at: now,
-    },
-    {
-      id: uuid(),
-      name: 'People I Love',
-      description: 'Relationships and connections',
-      color: 'oklch(0.65 0.2 350)', // rose
-      icon: 'heart',
-      is_pinned: false,
-      is_archived: false,
-      order: 2,
-      created_at: now,
-      updated_at: now,
-    },
-  ];
-};
+/*
+ * Central hook for journal data. Reads come from three parallel queries,
+ * writes go through optimistic mutations. The public API mirrors the old
+ * localStorage-backed hook so screens didn't need to change.
+ */
+
+const STALE_TIME = 30_000;
+
+function now() {
+  return new Date().toISOString();
+}
 
 export function useJournalData() {
-  const [entries, setEntries] = useLocalStorage<Entry[]>('tightly-entries', []);
-  const [chapters, setChapters] = useLocalStorage<Chapter[]>('tightly-chapters', []);
-  const [books, setBooks] = useLocalStorage<Book[]>('tightly-books', []);
-  const [hasSeeded, setHasSeeded] = useLocalStorage<boolean>('tightly-has-seeded-content', false);
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const userId = user?.id;
+  const enabled = Boolean(userId && supabase);
 
-  // Seed starter chapters on first load only. No sample entry.
-  useEffect(() => {
-    if (!hasSeeded && (!chapters || chapters.length === 0)) {
-      setChapters(createStarterChapters());
-      setHasSeeded(true);
-    }
-  }, [hasSeeded, setHasSeeded, setChapters, chapters]);
+  const entriesKey = ['entries', userId] as const;
+  const chaptersKey = ['chapters', userId] as const;
+  const booksKey = ['books', userId] as const;
 
-  const entryList = (entries || []).map(e => ({
-    ...e,
-    is_starred: e.is_starred ?? false,
-    is_draft: e.is_draft ?? false,
-    chapter_id: e.chapter_id ?? null,
-    prompt_used: e.prompt_used ?? null,
-  }));
-  
-  const chapterList = (chapters || []).map(c => ({
-    ...c,
-    is_pinned: c.is_pinned ?? false,
-    is_archived: c.is_archived ?? false,
-    order: c.order ?? 0,
-  }));
+  const entriesQuery = useQuery({
+    queryKey: entriesKey,
+    queryFn: () => db.fetchEntries(userId!),
+    enabled,
+    staleTime: STALE_TIME,
+  });
 
-  const bookList = books || [];
+  const chaptersQuery = useQuery({
+    queryKey: chaptersKey,
+    queryFn: () => db.fetchChapters(userId!),
+    enabled,
+    staleTime: STALE_TIME,
+  });
 
-  const handleSaveEntry = (entry: Entry) => {
-    try {
-      setEntries((current) => {
-        const list = current || [];
-        const existing = list.findIndex(e => e.id === entry.id);
-        if (existing >= 0) {
-          const updated = [...list];
-          updated[existing] = { ...entry, updated_at: new Date().toISOString() };
-          return updated;
-        }
-        return [...list, entry];
-      });
-    } catch (error) {
+  const booksQuery = useQuery({
+    queryKey: booksKey,
+    queryFn: () => db.fetchBooks(userId!),
+    enabled,
+    staleTime: STALE_TIME,
+  });
+
+  // --- Entries ---
+
+  const saveEntryMutation = useMutation({
+    mutationFn: async (entry: Entry) => {
+      if (!userId) throw new Error('Not signed in');
+      const stamped: Entry = { ...entry, updated_at: now() };
+      await db.upsertEntry(userId, stamped);
+      return stamped;
+    },
+    onMutate: async (entry) => {
+      await qc.cancelQueries({ queryKey: entriesKey });
+      const prev = qc.getQueryData<Entry[]>(entriesKey) ?? [];
+      const idx = prev.findIndex(e => e.id === entry.id);
+      const next = idx >= 0
+        ? prev.map(e => (e.id === entry.id ? { ...entry, updated_at: now() } : e))
+        : [{ ...entry, updated_at: now() }, ...prev];
+      qc.setQueryData(entriesKey, next);
+      return { prev };
+    },
+    onError: (_err, _entry, ctx) => {
+      if (ctx?.prev) qc.setQueryData(entriesKey, ctx.prev);
       toast.error('Failed to save memory entry. Please try again.');
-      throw error;
-    }
-  };
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
+  });
 
-  const handleDeleteEntry = (entryId: string) => {
-    try {
-      setEntries((current) => (current || []).filter(e => e.id !== entryId));
-    } catch (error) {
+  const deleteEntryMutation = useMutation({
+    mutationFn: (entryId: string) => db.deleteEntry(entryId),
+    onMutate: async (entryId) => {
+      await qc.cancelQueries({ queryKey: entriesKey });
+      const prev = qc.getQueryData<Entry[]>(entriesKey) ?? [];
+      qc.setQueryData(entriesKey, prev.filter(e => e.id !== entryId));
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(entriesKey, ctx.prev);
       toast.error('Failed to delete memory entry. Please try again.');
-      throw error;
-    }
-  };
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
+  });
 
-  const handleToggleStar = (entryId: string) => {
-    setEntries((current) => {
-      const list = current || [];
-      return list.map(e => 
-        e.id === entryId 
-          ? { ...e, is_starred: !e.is_starred, updated_at: new Date().toISOString() }
-          : e
+  const toggleStarMutation = useMutation({
+    mutationFn: async (entryId: string) => {
+      const current = (qc.getQueryData<Entry[]>(entriesKey) ?? []).find(e => e.id === entryId);
+      const next = !(current?.is_starred ?? false);
+      await db.setEntryStar(entryId, next);
+      return { entryId, next };
+    },
+    onMutate: async (entryId) => {
+      await qc.cancelQueries({ queryKey: entriesKey });
+      const prev = qc.getQueryData<Entry[]>(entriesKey) ?? [];
+      qc.setQueryData(
+        entriesKey,
+        prev.map(e => (e.id === entryId ? { ...e, is_starred: !e.is_starred, updated_at: now() } : e))
       );
-    });
-  };
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(entriesKey, ctx.prev);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
+  });
 
-  const handleSaveChapter = (chapter: Chapter) => {
-    try {
-      setChapters((current) => {
-        const list = current || [];
-        const existing = list.findIndex(c => c.id === chapter.id);
-        if (existing >= 0) {
-          const updated = [...list];
-          updated[existing] = { ...chapter, updated_at: new Date().toISOString() };
-          return updated;
-        }
-        return [...list, { ...chapter, order: list.length }];
-      });
-    } catch (error) {
-      toast.error('Failed to save chapter. Please try again.');
-      throw error;
-    }
-  };
-
-  const handleDeleteChapter = (chapterId: string) => {
-    try {
-      setChapters((current) => (current || []).filter(c => c.id !== chapterId));
-      setEntries((current) => {
-        const list = current || [];
-        return list.map(e => e.chapter_id === chapterId ? { ...e, chapter_id: null } : e);
-      });
-    } catch (error) {
-      toast.error('Failed to delete chapter. Please try again.');
-      throw error;
-    }
-  };
-
-  const handleReorderChapters = (startIndex: number, endIndex: number) => {
-    setChapters((current) => {
-      const list = [...(current || [])];
-      const [moved] = list.splice(startIndex, 1);
-      list.splice(endIndex, 0, moved);
-      return list.map((c, idx) => ({ ...c, order: idx }));
-    });
-  };
-
-  const handleAssignChapter = (entryId: string, chapterId: string | null) => {
-    try {
-      setEntries((current) => {
-        const list = current || [];
-        return list.map(e => 
-          e.id === entryId 
-            ? { ...e, chapter_id: chapterId, updated_at: new Date().toISOString() }
-            : e
-        );
-      });
-    } catch (error) {
+  const assignChapterMutation = useMutation({
+    mutationFn: ({ entryId, chapterId }: { entryId: string; chapterId: string | null }) =>
+      db.setEntryChapter(entryId, chapterId),
+    onMutate: async ({ entryId, chapterId }) => {
+      await qc.cancelQueries({ queryKey: entriesKey });
+      const prev = qc.getQueryData<Entry[]>(entriesKey) ?? [];
+      qc.setQueryData(
+        entriesKey,
+        prev.map(e => (e.id === entryId ? { ...e, chapter_id: chapterId, updated_at: now() } : e))
+      );
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(entriesKey, ctx.prev);
       toast.error('Failed to assign chapter. Please try again.');
-      throw error;
-    }
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
+  });
+
+  // --- Chapters ---
+
+  const saveChapterMutation = useMutation({
+    mutationFn: async (chapter: Chapter) => {
+      if (!userId) throw new Error('Not signed in');
+      const stamped = { ...chapter, updated_at: now() };
+      await db.upsertChapter(userId, stamped);
+      return stamped;
+    },
+    onMutate: async (chapter) => {
+      await qc.cancelQueries({ queryKey: chaptersKey });
+      const prev = qc.getQueryData<Chapter[]>(chaptersKey) ?? [];
+      const exists = prev.some(c => c.id === chapter.id);
+      const next = exists
+        ? prev.map(c => (c.id === chapter.id ? { ...chapter, updated_at: now() } : c))
+        : [...prev, { ...chapter, order: chapter.order ?? prev.length }];
+      qc.setQueryData(chaptersKey, next);
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(chaptersKey, ctx.prev);
+      toast.error('Failed to save chapter. Please try again.');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: chaptersKey }),
+  });
+
+  const deleteChapterMutation = useMutation({
+    mutationFn: (chapterId: string) => db.deleteChapter(chapterId),
+    onMutate: async (chapterId) => {
+      await qc.cancelQueries({ queryKey: chaptersKey });
+      await qc.cancelQueries({ queryKey: entriesKey });
+      const prevChapters = qc.getQueryData<Chapter[]>(chaptersKey) ?? [];
+      const prevEntries = qc.getQueryData<Entry[]>(entriesKey) ?? [];
+      qc.setQueryData(chaptersKey, prevChapters.filter(c => c.id !== chapterId));
+      qc.setQueryData(
+        entriesKey,
+        prevEntries.map(e => (e.chapter_id === chapterId ? { ...e, chapter_id: null } : e))
+      );
+      return { prevChapters, prevEntries };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prevChapters) qc.setQueryData(chaptersKey, ctx.prevChapters);
+      if (ctx?.prevEntries) qc.setQueryData(entriesKey, ctx.prevEntries);
+      toast.error('Failed to delete chapter. Please try again.');
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: chaptersKey });
+      qc.invalidateQueries({ queryKey: entriesKey });
+    },
+  });
+
+  const reorderChaptersMutation = useMutation({
+    mutationFn: (updates: { id: string; order: number }[]) => db.reorderChapters(updates),
+    onSettled: () => qc.invalidateQueries({ queryKey: chaptersKey }),
+  });
+
+  const reorderChapters = (startIndex: number, endIndex: number) => {
+    const prev = qc.getQueryData<Chapter[]>(chaptersKey) ?? [];
+    const list = [...prev];
+    const [moved] = list.splice(startIndex, 1);
+    list.splice(endIndex, 0, moved);
+    const reordered = list.map((c, idx) => ({ ...c, order: idx }));
+    qc.setQueryData(chaptersKey, reordered);
+    reorderChaptersMutation.mutate(reordered.map(c => ({ id: c.id, order: c.order })));
   };
 
-  const handleSaveBook = (book: Book) => {
-    setBooks((current) => {
-      const list = current || [];
-      const existing = list.findIndex(b => b.id === book.id);
-      if (existing >= 0) {
-        const updated = [...list];
-        updated[existing] = { ...book, updated_at: new Date().toISOString() };
-        return updated;
-      }
-      return [...list, book];
-    });
-  };
+  // --- Books ---
 
-  const handleDeleteBook = (bookId: string) => {
-    setBooks((current) => (current || []).filter(b => b.id !== bookId));
-  };
+  const saveBookMutation = useMutation({
+    mutationFn: async (book: Book) => {
+      if (!userId) throw new Error('Not signed in');
+      const stamped = { ...book, updated_at: now() };
+      await db.upsertBook(userId, stamped);
+      return stamped;
+    },
+    onMutate: async (book) => {
+      await qc.cancelQueries({ queryKey: booksKey });
+      const prev = qc.getQueryData<Book[]>(booksKey) ?? [];
+      const exists = prev.some(b => b.id === book.id);
+      const next = exists
+        ? prev.map(b => (b.id === book.id ? { ...book, updated_at: now() } : b))
+        : [{ ...book, updated_at: now() }, ...prev];
+      qc.setQueryData(booksKey, next);
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(booksKey, ctx.prev);
+      toast.error('Failed to save book. Please try again.');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: booksKey }),
+  });
+
+  const deleteBookMutation = useMutation({
+    mutationFn: (bookId: string) => db.deleteBook(bookId),
+    onMutate: async (bookId) => {
+      await qc.cancelQueries({ queryKey: booksKey });
+      const prev = qc.getQueryData<Book[]>(booksKey) ?? [];
+      qc.setQueryData(booksKey, prev.filter(b => b.id !== bookId));
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(booksKey, ctx.prev);
+      toast.error('Failed to delete book. Please try again.');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: booksKey }),
+  });
 
   return {
-    entries: entryList,
-    chapters: chapterList,
-    books: bookList,
-    saveEntry: handleSaveEntry,
-    deleteEntry: handleDeleteEntry,
-    toggleStar: handleToggleStar,
-    saveChapter: handleSaveChapter,
-    deleteChapter: handleDeleteChapter,
-    reorderChapters: handleReorderChapters,
-    assignChapter: handleAssignChapter,
-    saveBook: handleSaveBook,
-    deleteBook: handleDeleteBook,
+    entries: entriesQuery.data ?? [],
+    chapters: chaptersQuery.data ?? [],
+    books: booksQuery.data ?? [],
+    isLoading: entriesQuery.isLoading || chaptersQuery.isLoading || booksQuery.isLoading,
+    saveEntry: (entry: Entry) => saveEntryMutation.mutate(entry),
+    deleteEntry: (entryId: string) => deleteEntryMutation.mutate(entryId),
+    toggleStar: (entryId: string) => toggleStarMutation.mutate(entryId),
+    saveChapter: (chapter: Chapter) => saveChapterMutation.mutate(chapter),
+    deleteChapter: (chapterId: string) => deleteChapterMutation.mutate(chapterId),
+    reorderChapters,
+    assignChapter: (entryId: string, chapterId: string | null) =>
+      assignChapterMutation.mutate({ entryId, chapterId }),
+    saveBook: (book: Book) => saveBookMutation.mutate(book),
+    deleteBook: (bookId: string) => deleteBookMutation.mutate(bookId),
   };
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,343 @@
+import { supabase } from './supabase';
+import { Entry, Chapter, Book, Photo, LocationSuggestion, ChapterIcon, BookTheme } from './types';
+import { getSignedPhotoUrls, deletePhotos } from './photos';
+
+/*
+ * Mapping layer between our TypeScript domain types and Postgres rows.
+ *
+ * The DB stores entries.memory_date (date) and entry_photos as a separate
+ * table; the client-side Entry type keeps photos inline and uses `date`
+ * as its memory-date field. These helpers keep the shapes aligned.
+ */
+
+function assertSupabase() {
+  if (!supabase) throw new Error('Supabase is not configured — check NEXT_PUBLIC_SUPABASE_URL / SUPABASE_PUBLISHABLE_KEY');
+  return supabase;
+}
+
+interface EntryRow {
+  id: string;
+  user_id: string;
+  chapter_id: string | null;
+  memory_date: string | null;
+  title_user: string | null;
+  title_ai: string | null;
+  transcript: string | null;
+  story_ai: string | null;
+  highlights_ai: string[] | null;
+  tags_ai: Entry['tags_ai'];
+  location_suggestions: LocationSuggestion[] | null;
+  manual_locations: string[] | null;
+  missing_info_questions: string[] | null;
+  uncertain_claims: string[] | null;
+  is_locked: boolean;
+  is_starred: boolean;
+  is_draft: boolean;
+  prompt_used: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PhotoRow {
+  id: string;
+  entry_id: string;
+  storage_path: string;
+  width: number | null;
+  height: number | null;
+  bytes: number | null;
+  position: number;
+  created_at: string;
+}
+
+function rowToEntry(row: EntryRow, photos: Photo[]): Entry {
+  return {
+    id: row.id,
+    date: row.memory_date ?? row.created_at.slice(0, 10),
+    title_user: row.title_user,
+    title_ai: row.title_ai,
+    transcript: row.transcript,
+    story_ai: row.story_ai,
+    highlights_ai: row.highlights_ai,
+    tags_ai: row.tags_ai,
+    location_suggestions: row.location_suggestions,
+    manual_locations: row.manual_locations,
+    missing_info_questions: row.missing_info_questions,
+    uncertain_claims: row.uncertain_claims,
+    is_locked: row.is_locked,
+    is_starred: row.is_starred,
+    is_draft: row.is_draft,
+    chapter_id: row.chapter_id,
+    photos,
+    prompt_used: row.prompt_used,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function entryToRow(userId: string, entry: Entry) {
+  return {
+    id: entry.id,
+    user_id: userId,
+    chapter_id: entry.chapter_id,
+    memory_date: entry.date ? entry.date.slice(0, 10) : null,
+    title_user: entry.title_user,
+    title_ai: entry.title_ai,
+    transcript: entry.transcript,
+    story_ai: entry.story_ai,
+    highlights_ai: entry.highlights_ai,
+    tags_ai: entry.tags_ai,
+    location_suggestions: entry.location_suggestions,
+    manual_locations: entry.manual_locations,
+    missing_info_questions: entry.missing_info_questions,
+    uncertain_claims: entry.uncertain_claims,
+    is_locked: entry.is_locked,
+    is_starred: entry.is_starred,
+    is_draft: entry.is_draft,
+    prompt_used: entry.prompt_used,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Entries
+// ---------------------------------------------------------------------------
+
+export async function fetchEntries(userId: string): Promise<Entry[]> {
+  const sb = assertSupabase();
+  const [entriesRes, photosRes] = await Promise.all([
+    sb.from('entries').select('*').eq('user_id', userId).order('memory_date', { ascending: false, nullsFirst: false }),
+    sb.from('entry_photos').select('*').eq('user_id', userId).order('position', { ascending: true }),
+  ]);
+  if (entriesRes.error) throw entriesRes.error;
+  if (photosRes.error) throw photosRes.error;
+
+  const photoRows = (photosRes.data ?? []) as PhotoRow[];
+  const signed = await getSignedPhotoUrls(photoRows.map(p => p.storage_path));
+
+  const photosByEntry = new Map<string, Photo[]>();
+  for (const row of photoRows) {
+    const list = photosByEntry.get(row.entry_id) ?? [];
+    list.push({
+      id: row.id,
+      entry_id: row.entry_id,
+      storage_path: row.storage_path,
+      storage_url: signed[row.storage_path] ?? '',
+      width: row.width,
+      height: row.height,
+      bytes: row.bytes,
+      created_at: row.created_at,
+    });
+    photosByEntry.set(row.entry_id, list);
+  }
+
+  return (entriesRes.data as EntryRow[]).map(row =>
+    rowToEntry(row, photosByEntry.get(row.id) ?? [])
+  );
+}
+
+export async function upsertEntry(userId: string, entry: Entry): Promise<Entry> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('entries').upsert(entryToRow(userId, entry));
+  if (error) throw error;
+
+  // Sync entry_photos: delete rows no longer present, insert new ones.
+  const incoming = entry.photos ?? [];
+  const { data: existingRows, error: fetchErr } = await sb
+    .from('entry_photos')
+    .select('id, storage_path')
+    .eq('entry_id', entry.id);
+  if (fetchErr) throw fetchErr;
+
+  const incomingIds = new Set(incoming.map(p => p.id));
+  const toDelete = (existingRows ?? []).filter(r => !incomingIds.has(r.id));
+  if (toDelete.length) {
+    const { error: delErr } = await sb.from('entry_photos').delete().in('id', toDelete.map(r => r.id));
+    if (delErr) throw delErr;
+    await deletePhotos(toDelete.map(r => r.storage_path));
+  }
+
+  const existingIds = new Set((existingRows ?? []).map(r => r.id));
+  const toInsert = incoming
+    .filter(p => !existingIds.has(p.id))
+    .map((p, idx) => ({
+      id: p.id,
+      entry_id: entry.id,
+      user_id: userId,
+      storage_path: p.storage_path,
+      width: p.width ?? null,
+      height: p.height ?? null,
+      bytes: p.bytes ?? null,
+      position: idx,
+    }));
+  if (toInsert.length) {
+    const { error: insErr } = await sb.from('entry_photos').insert(toInsert);
+    if (insErr) throw insErr;
+  }
+
+  // Update positions for existing rows (idempotent).
+  for (let i = 0; i < incoming.length; i++) {
+    const p = incoming[i];
+    if (existingIds.has(p.id)) {
+      await sb.from('entry_photos').update({ position: i }).eq('id', p.id);
+    }
+  }
+
+  return entry;
+}
+
+export async function deleteEntry(entryId: string): Promise<void> {
+  const sb = assertSupabase();
+  const { data: photos } = await sb.from('entry_photos').select('storage_path').eq('entry_id', entryId);
+  const { error } = await sb.from('entries').delete().eq('id', entryId);
+  if (error) throw error;
+  if (photos?.length) await deletePhotos(photos.map(p => p.storage_path));
+}
+
+export async function setEntryStar(entryId: string, starred: boolean): Promise<void> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('entries').update({ is_starred: starred }).eq('id', entryId);
+  if (error) throw error;
+}
+
+export async function setEntryChapter(entryId: string, chapterId: string | null): Promise<void> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('entries').update({ chapter_id: chapterId }).eq('id', entryId);
+  if (error) throw error;
+}
+
+// ---------------------------------------------------------------------------
+// Chapters
+// ---------------------------------------------------------------------------
+
+interface ChapterRow {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  color: string;
+  icon: ChapterIcon;
+  is_pinned: boolean;
+  is_archived: boolean;
+  order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToChapter(row: ChapterRow): Chapter {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    color: row.color,
+    icon: row.icon,
+    is_pinned: row.is_pinned,
+    is_archived: row.is_archived,
+    order: row.order,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export async function fetchChapters(userId: string): Promise<Chapter[]> {
+  const sb = assertSupabase();
+  const { data, error } = await sb
+    .from('chapters')
+    .select('*')
+    .eq('user_id', userId)
+    .order('order', { ascending: true });
+  if (error) throw error;
+  return (data as ChapterRow[]).map(rowToChapter);
+}
+
+export async function upsertChapter(userId: string, chapter: Chapter): Promise<Chapter> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('chapters').upsert({
+    id: chapter.id,
+    user_id: userId,
+    name: chapter.name,
+    description: chapter.description,
+    color: chapter.color,
+    icon: chapter.icon,
+    is_pinned: chapter.is_pinned,
+    is_archived: chapter.is_archived,
+    order: chapter.order,
+  });
+  if (error) throw error;
+  return chapter;
+}
+
+export async function deleteChapter(chapterId: string): Promise<void> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('chapters').delete().eq('id', chapterId);
+  if (error) throw error;
+}
+
+export async function reorderChapters(updates: { id: string; order: number }[]): Promise<void> {
+  const sb = assertSupabase();
+  await Promise.all(
+    updates.map(u => sb.from('chapters').update({ order: u.order }).eq('id', u.id))
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Books
+// ---------------------------------------------------------------------------
+
+interface BookRow {
+  id: string;
+  user_id: string;
+  title: string;
+  subtitle: string | null;
+  theme: BookTheme;
+  entry_ids: string[];
+  is_draft: boolean;
+  pdf_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToBook(row: BookRow): Book {
+  return {
+    id: row.id,
+    title: row.title,
+    subtitle: row.subtitle,
+    theme: row.theme,
+    entry_ids: row.entry_ids,
+    is_draft: row.is_draft,
+    pdf_url: row.pdf_url,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export async function fetchBooks(userId: string): Promise<Book[]> {
+  const sb = assertSupabase();
+  const { data, error } = await sb
+    .from('books')
+    .select('*')
+    .eq('user_id', userId)
+    .order('updated_at', { ascending: false });
+  if (error) throw error;
+  return (data as BookRow[]).map(rowToBook);
+}
+
+export async function upsertBook(userId: string, book: Book): Promise<Book> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('books').upsert({
+    id: book.id,
+    user_id: userId,
+    title: book.title,
+    subtitle: book.subtitle,
+    theme: book.theme,
+    entry_ids: book.entry_ids,
+    is_draft: book.is_draft,
+    pdf_url: book.pdf_url,
+  });
+  if (error) throw error;
+  return book;
+}
+
+export async function deleteBook(bookId: string): Promise<void> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('books').delete().eq('id', bookId);
+  if (error) throw error;
+}

--- a/src/lib/photos.ts
+++ b/src/lib/photos.ts
@@ -1,0 +1,93 @@
+import { v4 as uuid } from 'uuid';
+import { supabase } from './supabase';
+
+const BUCKET = 'journal-photos';
+const MAX_EDGE = 2048;
+const QUALITY = 0.85;
+const SIGNED_URL_TTL = 60 * 60; // 1 hour
+
+export interface UploadedPhoto {
+  storage_path: string;
+  width: number;
+  height: number;
+  bytes: number;
+}
+
+/** Resize an image File down to MAX_EDGE on its longest side and re-encode as JPEG. */
+export async function resizeImage(file: File): Promise<{ blob: Blob; width: number; height: number }> {
+  const bitmap = await createImageBitmap(file).catch(() => null);
+  if (!bitmap) {
+    // Fall back to original if decoding fails (e.g. HEIC on an unsupported browser).
+    return { blob: file, width: 0, height: 0 };
+  }
+  const { width: sw, height: sh } = bitmap;
+  const scale = Math.min(1, MAX_EDGE / Math.max(sw, sh));
+  const width = Math.round(sw * scale);
+  const height = Math.round(sh * scale);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context unavailable');
+  ctx.drawImage(bitmap, 0, 0, width, height);
+  bitmap.close();
+
+  const blob: Blob = await new Promise((resolve, reject) => {
+    canvas.toBlob(
+      b => (b ? resolve(b) : reject(new Error('Failed to encode image'))),
+      'image/jpeg',
+      QUALITY
+    );
+  });
+  return { blob, width, height };
+}
+
+/** Upload one photo for an entry; returns the canonical storage path. */
+export async function uploadEntryPhoto(
+  userId: string,
+  entryId: string,
+  file: File
+): Promise<UploadedPhoto> {
+  if (!supabase) throw new Error('Supabase client not configured');
+  const { blob, width, height } = await resizeImage(file);
+  const fileName = `${uuid()}.jpg`;
+  const storage_path = `${userId}/${entryId}/${fileName}`;
+  const { error } = await supabase.storage
+    .from(BUCKET)
+    .upload(storage_path, blob, { contentType: 'image/jpeg', cacheControl: '3600', upsert: false });
+  if (error) throw error;
+  return { storage_path, width, height, bytes: blob.size };
+}
+
+/** Sign a storage path for one hour. */
+export async function getSignedPhotoUrl(storage_path: string): Promise<string> {
+  if (!supabase) return '';
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(storage_path, SIGNED_URL_TTL);
+  if (error || !data) return '';
+  return data.signedUrl;
+}
+
+/** Sign many paths in parallel, returning a map of path -> URL (empty string on failure). */
+export async function getSignedPhotoUrls(paths: string[]): Promise<Record<string, string>> {
+  if (!supabase || paths.length === 0) return {};
+  const unique = Array.from(new Set(paths));
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrls(unique, SIGNED_URL_TTL);
+  if (error || !data) return {};
+  const out: Record<string, string> = {};
+  for (const row of data) {
+    if (row.path && row.signedUrl) out[row.path] = row.signedUrl;
+  }
+  return out;
+}
+
+/** Remove objects from storage; errors are logged but not thrown so cleanup is best-effort. */
+export async function deletePhotos(paths: string[]): Promise<void> {
+  if (!supabase || paths.length === 0) return;
+  const { error } = await supabase.storage.from(BUCKET).remove(paths);
+  if (error) console.warn('Storage cleanup failed', error);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,7 +75,14 @@ export interface Entry {
 export interface Photo {
   id: string;
   entry_id: string;
+  // Canonical location inside the Supabase Storage bucket: "{user_id}/{entry_id}/{file}".
+  storage_path: string;
+  // Short-lived signed URL for <img src>. Populated by the data layer on read,
+  // and by the uploader (object URL or signed URL) during create.
   storage_url: string;
+  width?: number | null;
+  height?: number | null;
+  bytes?: number | null;
   created_at: string;
 }
 

--- a/supabase/migrations/20260422120000_init.sql
+++ b/supabase/migrations/20260422120000_init.sql
@@ -1,0 +1,299 @@
+-- Memory Journal: initial schema
+--
+-- Five tables plus a private Storage bucket for entry photos. All user data
+-- is guarded by RLS against auth.uid(). A handle_new_user() trigger on
+-- auth.users creates the matching profile row and seeds three starter
+-- chapters (Growing Up / Adventures / People I Love) so first-time users
+-- have something to click into.
+
+set check_function_bodies = off;
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- profiles (1:1 with auth.users)
+-- ---------------------------------------------------------------------------
+
+create table public.profiles (
+  id            uuid primary key references auth.users(id) on delete cascade,
+  display_name  text,
+  locale        text,
+  voice_sample  text,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+create trigger profiles_set_updated_at
+  before update on public.profiles
+  for each row execute function public.set_updated_at();
+
+alter table public.profiles enable row level security;
+
+create policy "profiles: owner can select"
+  on public.profiles for select
+  using (auth.uid() = id);
+
+create policy "profiles: owner can update"
+  on public.profiles for update
+  using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+-- profiles inserts are handled by the handle_new_user() trigger below.
+
+-- ---------------------------------------------------------------------------
+-- chapters
+-- ---------------------------------------------------------------------------
+
+create table public.chapters (
+  id           uuid primary key default gen_random_uuid(),
+  user_id      uuid not null references auth.users(id) on delete cascade,
+  name         text not null,
+  description  text,
+  color        text not null,
+  icon         text not null,
+  is_pinned    boolean not null default false,
+  is_archived  boolean not null default false,
+  "order"      integer not null default 0,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+create index chapters_user_id_idx on public.chapters(user_id, updated_at desc);
+
+create trigger chapters_set_updated_at
+  before update on public.chapters
+  for each row execute function public.set_updated_at();
+
+alter table public.chapters enable row level security;
+
+create policy "chapters: owner can select"
+  on public.chapters for select using (auth.uid() = user_id);
+
+create policy "chapters: owner can insert"
+  on public.chapters for insert with check (auth.uid() = user_id);
+
+create policy "chapters: owner can update"
+  on public.chapters for update
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy "chapters: owner can delete"
+  on public.chapters for delete using (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- entries
+-- ---------------------------------------------------------------------------
+
+create table public.entries (
+  id                       uuid primary key default gen_random_uuid(),
+  user_id                  uuid not null references auth.users(id) on delete cascade,
+  chapter_id               uuid references public.chapters(id) on delete set null,
+  memory_date              date,
+  title_user               text,
+  title_ai                 text,
+  transcript               text,
+  story_ai                 text,
+  highlights_ai            jsonb,                -- string[]
+  tags_ai                  jsonb,                -- { people, places, moods, themes }
+  location_suggestions     jsonb,                -- LocationSuggestion[]
+  manual_locations         jsonb,                -- string[]
+  missing_info_questions   jsonb,                -- string[]
+  uncertain_claims         jsonb,                -- string[]
+  is_locked                boolean not null default false,
+  is_starred               boolean not null default false,
+  is_draft                 boolean not null default false,
+  prompt_used              text,
+  search_tsv               tsvector generated always as (
+    setweight(to_tsvector('simple', coalesce(title_user, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(title_ai, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(transcript, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(story_ai, '')), 'B')
+  ) stored,
+  created_at               timestamptz not null default now(),
+  updated_at               timestamptz not null default now()
+);
+
+create index entries_user_id_idx       on public.entries(user_id, memory_date desc nulls last, created_at desc);
+create index entries_chapter_id_idx    on public.entries(chapter_id) where chapter_id is not null;
+create index entries_search_tsv_idx    on public.entries using gin(search_tsv);
+
+create trigger entries_set_updated_at
+  before update on public.entries
+  for each row execute function public.set_updated_at();
+
+alter table public.entries enable row level security;
+
+create policy "entries: owner can select"
+  on public.entries for select using (auth.uid() = user_id);
+
+create policy "entries: owner can insert"
+  on public.entries for insert with check (auth.uid() = user_id);
+
+create policy "entries: owner can update"
+  on public.entries for update
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy "entries: owner can delete"
+  on public.entries for delete using (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- entry_photos
+-- ---------------------------------------------------------------------------
+
+create table public.entry_photos (
+  id             uuid primary key default gen_random_uuid(),
+  entry_id       uuid not null references public.entries(id) on delete cascade,
+  user_id        uuid not null references auth.users(id) on delete cascade,
+  storage_path   text not null,      -- e.g. "uuid-user/uuid-entry/uuid-photo.jpg"
+  position       integer not null default 0,
+  width          integer,
+  height         integer,
+  bytes          integer,
+  created_at     timestamptz not null default now()
+);
+
+create index entry_photos_entry_id_idx on public.entry_photos(entry_id, position);
+
+alter table public.entry_photos enable row level security;
+
+create policy "entry_photos: owner can select"
+  on public.entry_photos for select using (auth.uid() = user_id);
+
+create policy "entry_photos: owner can insert"
+  on public.entry_photos for insert with check (auth.uid() = user_id);
+
+create policy "entry_photos: owner can update"
+  on public.entry_photos for update
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy "entry_photos: owner can delete"
+  on public.entry_photos for delete using (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- books
+-- ---------------------------------------------------------------------------
+
+create table public.books (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  title       text not null default '',
+  subtitle    text,
+  theme       text not null default 'classic',
+  entry_ids   uuid[] not null default '{}',
+  is_draft    boolean not null default false,
+  pdf_url     text,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index books_user_id_idx on public.books(user_id, updated_at desc);
+
+create trigger books_set_updated_at
+  before update on public.books
+  for each row execute function public.set_updated_at();
+
+alter table public.books enable row level security;
+
+create policy "books: owner can select"
+  on public.books for select using (auth.uid() = user_id);
+
+create policy "books: owner can insert"
+  on public.books for insert with check (auth.uid() = user_id);
+
+create policy "books: owner can update"
+  on public.books for update
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy "books: owner can delete"
+  on public.books for delete using (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- handle_new_user: create profile + starter chapters on signup
+-- ---------------------------------------------------------------------------
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id)
+    values (new.id)
+    on conflict (id) do nothing;
+
+  insert into public.chapters (user_id, name, description, color, icon, "order") values
+    (new.id, 'Growing Up',    'Childhood and family memories',     'oklch(0.75 0.18 75)',  'house',    0),
+    (new.id, 'Adventures',    'Travel and experiences',            'oklch(0.65 0.17 160)', 'airplane', 1),
+    (new.id, 'People I Love', 'Relationships and connections',     'oklch(0.65 0.2 350)',  'heart',    2);
+
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- ---------------------------------------------------------------------------
+-- Storage bucket: journal-photos
+-- ---------------------------------------------------------------------------
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  values (
+    'journal-photos',
+    'journal-photos',
+    false,
+    10 * 1024 * 1024, -- 10 MB per object; client resizes before upload anyway
+    array['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']
+  )
+  on conflict (id) do update set
+    public = excluded.public,
+    file_size_limit = excluded.file_size_limit,
+    allowed_mime_types = excluded.allowed_mime_types;
+
+-- Path convention: "{user_id}/{entry_id}/{file}". The first segment is the
+-- owner — compare it to auth.uid() for row-level access.
+
+create policy "journal-photos: owner can select"
+  on storage.objects for select
+  using (
+    bucket_id = 'journal-photos'
+    and auth.uid()::text = split_part(name, '/', 1)
+  );
+
+create policy "journal-photos: owner can insert"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'journal-photos'
+    and auth.uid()::text = split_part(name, '/', 1)
+  );
+
+create policy "journal-photos: owner can update"
+  on storage.objects for update
+  using (
+    bucket_id = 'journal-photos'
+    and auth.uid()::text = split_part(name, '/', 1)
+  )
+  with check (
+    bucket_id = 'journal-photos'
+    and auth.uid()::text = split_part(name, '/', 1)
+  );
+
+create policy "journal-photos: owner can delete"
+  on storage.objects for delete
+  using (
+    bucket_id = 'journal-photos'
+    and auth.uid()::text = split_part(name, '/', 1)
+  );


### PR DESCRIPTION
Replaces the localStorage-backed journal with real Postgres storage, so entries, chapters, books, and photos survive across devices.

## Schema (`supabase/migrations/20260422120000_init.sql`)
- `profiles` (1:1 with `auth.users`), `chapters`, `entries`, `entry_photos`, `books`
- RLS everywhere: `auth.uid() = user_id` for every row; Storage paths validated via `split_part(name, '/', 1)`
- `entries.search_tsv` generated `tsvector` + `gin` index for search later
- `handle_new_user()` trigger creates the profile row **and** seeds three starter chapters (Growing Up / Adventures / People I Love) on signup
- Private `journal-photos` bucket, 10 MB cap, JPEG/PNG/WEBP/HEIC allowed

## Client
- `src/lib/db.ts` — typed CRUD wrappers (entries join `entry_photos`, sign URLs on read, diff-sync photo rows on write)
- `src/lib/photos.ts` — canvas resize to 2048 px longest edge / 85% JPEG, upload to Storage, signed-URL helpers
- `src/hooks/use-journal-data.ts` — rewritten on TanStack Query with optimistic mutations; public API preserved
- `QueryClientProvider` added at the App root
- `EntryEditScreen` uploads photos to Storage on drop instead of stashing base64 in `localStorage`

## Not in this PR
- No migration of existing `localStorage` data — per decision to wipe and restart (no real users yet)
- Export / full-backup, Stripe, UI polish — Phase 2+

Schema already applied to the production Supabase project (`oaxmyiavftperikuwohy`) via Management API, so merging this deploys the matching client.