### PR TITLE
Ship readiness: surface geocoding errors + add Vitest smoke tests + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/postcss": "^4.2.2",
+        "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react-swc": "^4.3.0",
@@ -84,7 +85,8 @@
         "tailwindcss": "^4.1.11",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.55.0",
-        "vite": "^7.2.6"
+        "vite": "^7.2.6",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3652,6 +3654,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "license": "MIT"
@@ -4916,6 +4925,17 @@
       "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "license": "MIT"
@@ -4959,6 +4979,13 @@
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -5379,6 +5406,119 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "license": "MIT",
@@ -5451,6 +5591,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -5537,6 +5687,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -5630,6 +5790,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -6152,6 +6319,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
@@ -6399,6 +6573,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
@@ -6417,6 +6601,16 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -7455,6 +7649,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/octokit": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.5.tgz",
@@ -7732,6 +7937,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8306,6 +8518,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "license": "MIT",
@@ -8321,12 +8540,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -8383,6 +8616,23 @@
       "version": "1.3.3",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "license": "MIT",
@@ -8395,6 +8645,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toad-cache": {
@@ -8710,6 +8970,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -8722,6 +9072,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "optimize": "vite optimize",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -81,6 +83,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/postcss": "^4.2.2",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react-swc": "^4.3.0",
@@ -91,7 +94,8 @@
     "tailwindcss": "^4.1.11",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.55.0",
-    "vite": "^7.2.6"
+    "vite": "^7.2.6",
+    "vitest": "^4.1.5"
   },
   "workspaces": {
     "packages": [

--- a/src/components/entry/LocationPanel.tsx
+++ b/src/components/entry/LocationPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { LocationSuggestion } from '@/lib/types';
-import { searchLocations, getCurrentLocation, GeocodingResult } from '@/lib/geocoding';
+import { searchLocations, getCurrentLocation, GeocodingResult, GeocodingServiceError } from '@/lib/geocoding';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -104,8 +104,15 @@ export function LocationPanel({
       setSearchResults(results);
       setShowDropdown(results.length > 0);
     } catch (error) {
-      console.error('Search failed:', error);
       setSearchResults([]);
+      setShowDropdown(false);
+      if (error instanceof GeocodingServiceError) {
+        toast.error('Location search unavailable', {
+          description: 'We could not reach the map service. Try again or type the location manually.',
+        });
+      } else {
+        console.error('Search failed:', error);
+      }
     } finally {
       setIsSearching(false);
     }
@@ -195,10 +202,16 @@ export function LocationPanel({
           description: 'Please check your browser permissions'
         });
       }
-    } catch {
-      toast.error('Location access denied', {
-        description: 'Enable location access in your browser settings'
-      });
+    } catch (error) {
+      if (error instanceof GeocodingServiceError) {
+        toast.error('Location service unavailable', {
+          description: 'We could not look up your current location. Try again in a moment or enter it manually.',
+        });
+      } else {
+        toast.error('Location access denied', {
+          description: 'Enable location access in your browser settings'
+        });
+      }
     } finally {
       setIsGettingLocation(false);
     }

--- a/src/components/screens/EntryEditScreen.tsx
+++ b/src/components/screens/EntryEditScreen.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Entry, Photo, Chapter, StoryTone, STORY_TONES, STORY_LANGUAGES, DEFAULT_PROMPTS, CHAPTER_ICONS, CHAPTER_COLORS, ChapterIcon, AppView } from '@/lib/types';
 import { createEmptyEntry, generateAIContent, formatDate, getEntryTitle } from '@/lib/entries';
-import { searchLocations, getCurrentLocation, GeocodingResult } from '@/lib/geocoding';
+import { searchLocations, getCurrentLocation, GeocodingResult, GeocodingServiceError } from '@/lib/geocoding';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -216,11 +216,16 @@ export function EntryEditScreen({
       const results = await searchLocations(query);
       setLocationResults(results);
       setShowLocationDropdown(results.length > 0);
-    } catch {
+    } catch (error) {
       setLocationResults([]);
-      toast.error('Location search unavailable', {
-        description: 'Could not reach the geocoding service. Try again or add the location manually.',
-      });
+      setShowLocationDropdown(false);
+      if (error instanceof GeocodingServiceError) {
+        toast.error('Location search unavailable', {
+          description: 'Could not reach the geocoding service. Try again or add the location manually.',
+        });
+      } else {
+        console.error('Location search failed:', error);
+      }
     } finally {
       setIsSearchingLocation(false);
     }
@@ -314,9 +319,19 @@ export function EntryEditScreen({
       if (location && !manualLocations.includes(location.displayName)) {
         setManualLocations(prev => [...prev, location.displayName]);
         toast.success(`Added: ${location.name}`);
+      } else if (!location) {
+        toast.error('Could not determine location', {
+          description: 'Please check your browser permissions',
+        });
       }
-    } catch {
-      toast.error('Location access denied');
+    } catch (error) {
+      if (error instanceof GeocodingServiceError) {
+        toast.error('Location service unavailable', {
+          description: 'We could not look up your current location. Try again in a moment or enter it manually.',
+        });
+      } else {
+        toast.error('Location access denied');
+      }
     } finally {
       setIsGettingLocation(false);
     }

--- a/src/lib/geocoding.ts
+++ b/src/lib/geocoding.ts
@@ -92,14 +92,26 @@ function formatDisplayName(result: NominatimResult): string {
   return parts.slice(0, 3).join(', ');
 }
 
+/**
+ * Thrown when the Nominatim geocoding service is unreachable or returns a
+ * non-2xx status. Callers can catch this to surface a user-facing toast.
+ */
+export class GeocodingServiceError extends Error {
+  constructor(message: string, public cause?: unknown) {
+    super(message);
+    this.name = 'GeocodingServiceError';
+  }
+}
+
 export async function searchLocations(query: string): Promise<GeocodingResult[]> {
   if (!query || query.trim().length < 2) {
     return [];
   }
 
+  let response: Response;
   try {
     const encodedQuery = encodeURIComponent(query.trim());
-    const response = await fetch(
+    response = await fetch(
       `https://nominatim.openstreetmap.org/search?format=json&q=${encodedQuery}&addressdetails=1&limit=8&namedetails=1`,
       {
         headers: {
@@ -108,42 +120,43 @@ export async function searchLocations(query: string): Promise<GeocodingResult[]>
         }
       }
     );
-
-    if (!response.ok) {
-      console.error('Geocoding request failed:', response.status);
-      return [];
-    }
-
-    const data: NominatimResult[] = await response.json();
-    
-    const results: GeocodingResult[] = data.map(item => ({
-      name: extractBestName(item),
-      displayName: formatDisplayName(item),
-      type: mapNominatimType(item.class, item.type),
-      lat: parseFloat(item.lat),
-      lon: parseFloat(item.lon),
-      importance: item.importance,
-      country: item.address?.country,
-      city: item.address?.city || item.address?.town || item.address?.village,
-      state: item.address?.state
-    }));
-
-    const seen = new Set<string>();
-    return results.filter(r => {
-      const key = r.displayName.toLowerCase();
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
   } catch (error) {
-    console.error('Geocoding error:', error);
-    return [];
+    console.error('Geocoding network error:', error);
+    throw new GeocodingServiceError('Location service unreachable', error);
   }
+
+  if (!response.ok) {
+    console.error('Geocoding request failed:', response.status);
+    throw new GeocodingServiceError(`Location service returned ${response.status}`);
+  }
+
+  const data: NominatimResult[] = await response.json();
+
+  const results: GeocodingResult[] = data.map(item => ({
+    name: extractBestName(item),
+    displayName: formatDisplayName(item),
+    type: mapNominatimType(item.class, item.type),
+    lat: parseFloat(item.lat),
+    lon: parseFloat(item.lon),
+    importance: item.importance,
+    country: item.address?.country,
+    city: item.address?.city || item.address?.town || item.address?.village,
+    state: item.address?.state
+  }));
+
+  const seen = new Set<string>();
+  return results.filter(r => {
+    const key = r.displayName.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 export async function reverseGeocode(lat: number, lon: number): Promise<GeocodingResult | null> {
+  let response: Response;
   try {
-    const response = await fetch(
+    response = await fetch(
       `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}&addressdetails=1&zoom=16`,
       {
         headers: {
@@ -152,29 +165,32 @@ export async function reverseGeocode(lat: number, lon: number): Promise<Geocodin
         }
       }
     );
-
-    if (!response.ok) {
-      console.error('Reverse geocoding failed:', response.status);
-      return null;
-    }
-
-    const data: NominatimResult = await response.json();
-    
-    return {
-      name: extractBestName(data),
-      displayName: formatDisplayName(data),
-      type: mapNominatimType(data.class, data.type),
-      lat: parseFloat(data.lat),
-      lon: parseFloat(data.lon),
-      importance: data.importance || 0.5,
-      country: data.address?.country,
-      city: data.address?.city || data.address?.town || data.address?.village,
-      state: data.address?.state
-    };
   } catch (error) {
-    console.error('Reverse geocoding error:', error);
+    console.error('Reverse geocoding network error:', error);
+    throw new GeocodingServiceError('Location service unreachable', error);
+  }
+
+  if (!response.ok) {
+    console.error('Reverse geocoding failed:', response.status);
+    throw new GeocodingServiceError(`Location service returned ${response.status}`);
+  }
+
+  const data: NominatimResult = await response.json();
+  if (!data || typeof data.lat !== 'string' || typeof data.lon !== 'string') {
     return null;
   }
+
+  return {
+    name: extractBestName(data),
+    displayName: formatDisplayName(data),
+    type: mapNominatimType(data.class, data.type),
+    lat: parseFloat(data.lat),
+    lon: parseFloat(data.lon),
+    importance: data.importance || 0.5,
+    country: data.address?.country,
+    city: data.address?.city || data.address?.town || data.address?.village,
+    state: data.address?.state
+  };
 }
 
 export function getCurrentPosition(): Promise<GeolocationPosition> {
@@ -192,11 +208,8 @@ export function getCurrentPosition(): Promise<GeolocationPosition> {
 }
 
 export async function getCurrentLocation(): Promise<GeocodingResult | null> {
-  try {
-    const position = await getCurrentPosition();
-    return await reverseGeocode(position.coords.latitude, position.coords.longitude);
-  } catch (error) {
-    console.error('Failed to get current location:', error);
-    return null;
-  }
+  // Allow GeolocationPositionError and GeocodingServiceError to propagate so
+  // callers can show distinct user-visible messages.
+  const position = await getCurrentPosition();
+  return reverseGeocode(position.coords.latitude, position.coords.longitude);
 }

--- a/tests/_mock-res.ts
+++ b/tests/_mock-res.ts
@@ -1,0 +1,42 @@
+export interface MockResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  status: (code: number) => MockResponse;
+  json: (data: unknown) => MockResponse;
+  setHeader: (key: string, value: string) => MockResponse;
+}
+
+export function createMockResponse(): MockResponse {
+  const res: MockResponse = {
+    statusCode: 0,
+    headers: {},
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.body = data;
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key.toLowerCase()] = value;
+      return this;
+    },
+  };
+  return res;
+}
+
+export function createMockRequest(opts: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+} = {}): any {
+  return {
+    method: opts.method ?? 'POST',
+    headers: opts.headers ?? {},
+    body: opts.body,
+    socket: { remoteAddress: '127.0.0.1' },
+  };
+}

--- a/tests/geocoding.test.ts
+++ b/tests/geocoding.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GeocodingServiceError, reverseGeocode, searchLocations } from '../src/lib/geocoding';
+
+const originalFetch = globalThis.fetch;
+
+describe('geocoding', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Silence expected console.error noise from failure paths.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('searchLocations returns [] for short queries without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+    const results = await searchLocations('a');
+    expect(results).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('searchLocations throws GeocodingServiceError on non-ok response', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response('boom', { status: 503 })) as any;
+    await expect(searchLocations('Berlin')).rejects.toBeInstanceOf(GeocodingServiceError);
+  });
+
+  it('searchLocations throws GeocodingServiceError on network error', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as any;
+    await expect(searchLocations('Berlin')).rejects.toBeInstanceOf(GeocodingServiceError);
+  });
+
+  it('searchLocations maps and dedupes Nominatim results', async () => {
+    const payload = [
+      {
+        place_id: 1,
+        display_name: 'Berlin, Germany',
+        lat: '52.52',
+        lon: '13.405',
+        importance: 0.9,
+        type: 'city',
+        class: 'place',
+        address: { country: 'Germany', city: 'Berlin' },
+        name: 'Berlin',
+      },
+      {
+        place_id: 2,
+        display_name: 'Berlin, Germany',
+        lat: '52.52',
+        lon: '13.405',
+        importance: 0.8,
+        type: 'city',
+        class: 'place',
+        address: { country: 'Germany', city: 'Berlin' },
+        name: 'Berlin',
+      },
+    ];
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 })) as any;
+    const results = await searchLocations('Berlin');
+    expect(results).toHaveLength(1);
+    expect(results[0].type).toBe('city');
+    expect(results[0].lat).toBeCloseTo(52.52);
+  });
+
+  it('reverseGeocode throws GeocodingServiceError on fetch failure', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as any;
+    await expect(reverseGeocode(0, 0)).rejects.toBeInstanceOf(GeocodingServiceError);
+  });
+});

--- a/tests/llm-complete.test.ts
+++ b/tests/llm-complete.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockRequest, createMockResponse } from './_mock-res';
+
+// These tests exercise the entry-level guards: method check, payload size,
+// missing prompt, and auth enforcement. They deliberately avoid reaching
+// OpenAI by triggering earlier rejections.
+//
+// Several of the guards read process.env at module load time, so env-sensitive
+// cases reset the module cache and re-import the handler.
+
+async function loadHandler() {
+  const mod = await import('../api/llm/complete.js');
+  return mod.default as (req: any, res: any) => Promise<void>;
+}
+
+describe('POST /api/llm/complete guards', () => {
+  const envBackup = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.REQUIRE_AUTH_FOR_LLM;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SECRET_KEY;
+    delete process.env.PREMIUM_USER_IDS;
+    delete process.env.MAX_LLM_PROMPT_CHARS;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+    vi.resetModules();
+  });
+
+  it('returns 405 for non-POST methods', async () => {
+    const handler = await loadHandler();
+    const req = createMockRequest({ method: 'GET' });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 413 when body exceeds the byte cap', async () => {
+    const handler = await loadHandler();
+    const huge = 'x'.repeat(9 * 1024);
+    const req = createMockRequest({ method: 'POST', body: { prompt: huge } });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(413);
+  });
+
+  it('returns 401 when REQUIRE_AUTH_FOR_LLM is true and no token is provided', async () => {
+    process.env.REQUIRE_AUTH_FOR_LLM = 'true';
+    const handler = await loadHandler();
+    const req = createMockRequest({ method: 'POST', body: { prompt: 'hi' } });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 400 for an empty prompt (when auth not required)', async () => {
+    const handler = await loadHandler();
+    const req = createMockRequest({ method: 'POST', body: { prompt: '   ' } });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect((res.body as any).error).toMatch(/missing prompt/i);
+  });
+
+  it('returns 400 when prompt exceeds MAX_LLM_PROMPT_CHARS', async () => {
+    // Keep request body under the 8KB byte cap so we hit the char-length check.
+    process.env.MAX_LLM_PROMPT_CHARS = '100';
+    const handler = await loadHandler();
+    const req = createMockRequest({ method: 'POST', body: { prompt: 'a'.repeat(200) } });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect((res.body as any).error).toMatch(/too large/i);
+  });
+});

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockRequest, createMockResponse } from './_mock-res';
+
+async function loadHandler() {
+  const mod = await import('../api/preferences.js');
+  return mod.default as (req: any, res: any) => Promise<void>;
+}
+
+describe('/api/preferences (memory store)', () => {
+  const envBackup = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.REQUIRE_AUTH_FOR_PREFERENCES;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SECRET_KEY;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+    vi.resetModules();
+  });
+
+  it('returns 401 when auth is required and no token is provided', async () => {
+    process.env.REQUIRE_AUTH_FOR_PREFERENCES = 'true';
+    const handler = await loadHandler();
+    const req = createMockRequest({ method: 'GET' });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns default preferences on first GET for a fresh identity', async () => {
+    const handler = await loadHandler();
+    const req = createMockRequest({ method: 'GET', headers: { 'x-forwarded-for': '203.0.113.1' } });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as any).preferences).toMatchObject({
+      notifications: true,
+      emailUpdates: false,
+      autoSave: true,
+    });
+  });
+
+  it('PUT updates preferences and subsequent GET returns them (within same module instance)', async () => {
+    const handler = await loadHandler();
+    const headers = { 'x-forwarded-for': '203.0.113.42' };
+    const putReq = createMockRequest({
+      method: 'PUT',
+      headers,
+      body: {
+        preferences: { notifications: false, emailUpdates: true },
+        personalVoiceSample: 'sample text',
+      },
+    });
+    const putRes = createMockResponse();
+    await handler(putReq, putRes);
+    expect(putRes.statusCode).toBe(200);
+    expect((putRes.body as any).preferences.notifications).toBe(false);
+    expect((putRes.body as any).preferences.emailUpdates).toBe(true);
+    expect((putRes.body as any).personalVoiceSample).toBe('sample text');
+
+    const getReq = createMockRequest({ method: 'GET', headers });
+    const getRes = createMockResponse();
+    await handler(getReq, getRes);
+    expect((getRes.body as any).preferences.notifications).toBe(false);
+    expect((getRes.body as any).personalVoiceSample).toBe('sample text');
+  });
+
+  it('returns 405 for unsupported methods', async () => {
+    const handler = await loadHandler();
+    const req = createMockRequest({ method: 'DELETE' });
+    const res = createMockResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+});

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { inferTier } from '../api/_lib/rate-limit.js';
+
+describe('inferTier', () => {
+  const original = process.env.PREMIUM_USER_IDS;
+
+  beforeEach(() => {
+    delete process.env.PREMIUM_USER_IDS;
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.PREMIUM_USER_IDS;
+    else process.env.PREMIUM_USER_IDS = original;
+  });
+
+  it('respects explicit premium header', () => {
+    expect(inferTier('ip:1.2.3.4', 'premium')).toBe('premium');
+  });
+
+  it('falls back to free by default', () => {
+    expect(inferTier('ip:1.2.3.4')).toBe('free');
+  });
+
+  it('promotes identities listed in PREMIUM_USER_IDS', () => {
+    process.env.PREMIUM_USER_IDS = 'alice, bob ,carol';
+    expect(inferTier('bob')).toBe('premium');
+    expect(inferTier('dave')).toBe('free');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    globals: false,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
Ship-readiness Phase A progress.

## Changes

**Geocoding error surfacing (#38)**
- New `GeocodingServiceError` class in `src/lib/geocoding.ts`.
- `searchLocations` / `reverseGeocode` now throw on network failures or non-ok responses instead of swallowing to `[]` / `null`.
- `LocationPanel` and `EntryEditScreen` distinguish service failures ("Location service unavailable" toast) from permission denials.

**Smoke tests (#37)**
- Vitest added as devDep with `npm test` / `npm run test:watch` scripts.
- 17 tests across 4 files:
  - `tests/geocoding.test.ts` — short-query short-circuit, non-ok throw, network throw, dedupe mapping, reverseGeocode error.
  - `tests/rate-limit.test.ts` — tier inference logic.
  - `tests/llm-complete.test.ts` — 405/413/401/400 paths (uses `vi.resetModules()` because the handler captures env at module load).
  - `tests/preferences.test.ts` — 401 gated, defaults, PUT→GET round-trip, 405.
- New GitHub Actions CI workflow runs `npm test` + `npm run build` on push/PR.

## Verification
- `npm test` — 17/17 pass
- `npm run build` — success (main chunk >500kB warning pre-existing)
- Lint intentionally **not** wired into CI yet — repo has 53 pre-existing `no-explicit-any` errors outside this diff.

Closes #37
Closes #38