### PR TITLE
UI rework: dedupe nav, full-width cloud, 4-tab IA with Library + ⌘K search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,14 +22,11 @@ import { OnboardingTour, useOnboardingCompleted } from './components/onboarding/
 const PromptsScreen = lazy(() =>
   import('./components/screens/PromptsScreen').then((m) => ({ default: m.PromptsScreen })),
 );
-const ChaptersScreen = lazy(() =>
-  import('./components/screens/ChaptersScreen').then((m) => ({ default: m.ChaptersScreen })),
-);
 const ChapterDetailScreen = lazy(() =>
   import('./components/screens/ChapterDetailScreen').then((m) => ({ default: m.ChapterDetailScreen })),
 );
-const TimelineScreen = lazy(() =>
-  import('./components/screens/TimelineScreen').then((m) => ({ default: m.TimelineScreen })),
+const LibraryScreen = lazy(() =>
+  import('./components/screens/LibraryScreen').then((m) => ({ default: m.LibraryScreen })),
 );
 const SearchScreen = lazy(() =>
   import('./components/screens/SearchScreen').then((m) => ({ default: m.SearchScreen })),
@@ -89,6 +86,8 @@ function AppContent() {
         return `prompts-new-${view.promptId || 'default'}`;
       case 'print-builder':
         return `print-builder-${view.bookId || 'new'}-${view.step}`;
+      case 'library':
+        return `library-${view.tab || 'chapters'}`;
       default:
         return view.type;
     }
@@ -103,11 +102,11 @@ function AppContent() {
         return 'prompts';
       case 'chapters':
       case 'chapter-detail':
-        return 'chapters';
       case 'timeline':
-        return 'timeline';
+      case 'library':
+        return 'library';
       case 'search':
-        return 'search';
+        return 'home';
       case 'print':
       case 'print-builder':
         return 'print';
@@ -127,14 +126,8 @@ function AppContent() {
       case 'prompts':
         navigate({ type: 'prompts' });
         break;
-      case 'chapters':
-        navigate({ type: 'chapters' });
-        break;
-      case 'timeline':
-        navigate({ type: 'timeline' });
-        break;
-      case 'search':
-        navigate({ type: 'search' });
+      case 'library':
+        navigate({ type: 'library' });
         break;
       case 'print':
         navigate({ type: 'print' });
@@ -158,6 +151,13 @@ function AppContent() {
       if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
         e.preventDefault();
         navigate({ type: 'prompts-new' });
+        return;
+      }
+
+      // Ctrl/Cmd + K for search
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        navigate({ type: 'search' });
         return;
       }
       
@@ -213,21 +213,31 @@ function AppContent() {
           />
         );
 
+      case 'library':
       case 'chapters':
+      case 'timeline': {
+        const libraryTab: 'chapters' | 'timeline' =
+          currentView.type === 'timeline'
+            ? 'timeline'
+            : currentView.type === 'library'
+              ? currentView.tab || 'chapters'
+              : 'chapters';
         return (
-          <ChaptersScreen
+          <LibraryScreen
             chapters={chapters}
             entries={entries}
+            defaultTab={libraryTab}
             onNavigate={navigate}
             onSaveChapter={saveChapter}
             onDeleteChapter={deleteChapter}
           />
         );
+      }
 
       case 'chapter-detail':
         const chapter = chapters.find(c => c.id === currentView.chapterId);
         if (!chapter) {
-          navigate({ type: 'chapters' });
+          navigate({ type: 'library' });
           return null;
         }
         return (
@@ -238,15 +248,6 @@ function AppContent() {
             onSaveChapter={saveChapter}
             onDeleteChapter={deleteChapter}
             onToggleStar={toggleStar}
-          />
-        );
-
-      case 'timeline':
-        return (
-          <TimelineScreen
-            entries={entries}
-            chapters={chapters}
-            onNavigate={navigate}
           />
         );
 
@@ -365,6 +366,7 @@ function AppContent() {
           currentTab={getCurrentTab()}
           onTabChange={handleTabChange}
           onSettingsClick={() => setSettingsPanelOpen(true)}
+          onSearchClick={() => navigate({ type: 'search' })}
           isDarkMode={isDarkMode}
         />
       )}

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -1,5 +1,5 @@
 import { NavigationTab } from '@/lib/types';
-import { House, Sparkle, Books, Clock, MagnifyingGlass, Book } from '@phosphor-icons/react';
+import { House, Sparkle, Books, Book } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import { useLanguage } from '@/hooks/use-language.tsx';
 
@@ -15,9 +15,7 @@ export function BottomNav({ currentTab, onTabChange, isDarkMode }: BottomNavProp
   const tabs: { id: NavigationTab; labelKey: keyof typeof t.nav; Icon: typeof House }[] = [
     { id: 'home', labelKey: 'home', Icon: House },
     { id: 'prompts', labelKey: 'prompts', Icon: Sparkle },
-    { id: 'chapters', labelKey: 'chapters', Icon: Books },
-    { id: 'timeline', labelKey: 'timeline', Icon: Clock },
-    { id: 'search', labelKey: 'search', Icon: MagnifyingGlass },
+    { id: 'library', labelKey: 'library', Icon: Books },
     { id: 'print', labelKey: 'print', Icon: Book },
   ];
 

--- a/src/components/navigation/DesktopSidebar.tsx
+++ b/src/components/navigation/DesktopSidebar.tsx
@@ -3,11 +3,10 @@ import {
   House, 
   Sparkle, 
   Books, 
-  Clock,
-  MagnifyingGlass, 
   Printer,
   Gear,
-  SignOut
+  SignOut,
+  MagnifyingGlass
 } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import { useLanguage } from '@/hooks/use-language.tsx';
@@ -19,19 +18,18 @@ interface DesktopSidebarProps {
   currentTab: NavigationTab;
   onTabChange: (tab: NavigationTab) => void;
   onSettingsClick: () => void;
+  onSearchClick: () => void;
   isDarkMode: boolean;
 }
 
-export function DesktopSidebar({ currentTab, onTabChange, onSettingsClick, isDarkMode }: DesktopSidebarProps) {
+export function DesktopSidebar({ currentTab, onTabChange, onSettingsClick, onSearchClick, isDarkMode }: DesktopSidebarProps) {
   const { t } = useLanguage();
   const { signOut, user } = useAuth();
   
   const tabs: { id: NavigationTab; labelKey: keyof typeof t.nav; Icon: typeof House }[] = [
     { id: 'home', labelKey: 'home', Icon: House },
     { id: 'prompts', labelKey: 'prompts', Icon: Sparkle },
-    { id: 'chapters', labelKey: 'chapters', Icon: Books },
-    { id: 'timeline', labelKey: 'timeline', Icon: Clock },
-    { id: 'search', labelKey: 'search', Icon: MagnifyingGlass },
+    { id: 'library', labelKey: 'library', Icon: Books },
     { id: 'print', labelKey: 'print', Icon: Printer },
   ];
 
@@ -64,6 +62,21 @@ export function DesktopSidebar({ currentTab, onTabChange, onSettingsClick, isDar
         >
           Hold them tight
         </p>
+      </div>
+
+      {/* Search shortcut */}
+      <div className="px-3 pb-2">
+        <button
+          onClick={onSearchClick}
+          className="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl bg-muted/30 hover:bg-muted/50 border border-border/30 text-left text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={t.search.title}
+        >
+          <MagnifyingGlass weight="bold" className="w-4 h-4 flex-shrink-0" />
+          <span className="text-sm flex-1">{t.search.title}</span>
+          <kbd className="hidden lg:inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-border/40 text-[10px] font-mono">
+            ⌘K
+          </kbd>
+        </button>
       </div>
 
       {/* Navigation Tabs */}

--- a/src/components/navigation/NavigationMenu.tsx
+++ b/src/components/navigation/NavigationMenu.tsx
@@ -14,7 +14,6 @@ import {
   House,
   MagnifyingGlass,
   Sparkle,
-  Clock,
   CaretRight
 } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
@@ -46,25 +45,18 @@ export function NavigationMenu({ onNavigate, currentTab, isDarkMode }: Navigatio
       descriptionKey: 'prompts' as const
     },
     { 
-      id: 'chapters' as NavigationTab, 
-      labelKey: 'chapters' as const, 
+      id: 'library' as NavigationTab, 
+      labelKey: 'library' as const, 
       icon: Books, 
-      view: { type: 'chapters' } as AppView,
-      descriptionKey: 'chapters' as const
+      view: { type: 'library' } as AppView,
+      descriptionKey: 'library' as const
     },
-    { 
-      id: 'timeline' as NavigationTab, 
-      labelKey: 'timeline' as const, 
-      icon: Clock, 
-      view: { type: 'timeline' } as AppView,
-      descriptionKey: 'timeline' as const
-    },
-    { 
-      id: 'search' as NavigationTab, 
-      labelKey: 'search' as const, 
-      icon: MagnifyingGlass, 
+    {
+      id: 'home' as NavigationTab,
+      labelKey: 'search' as const,
+      icon: MagnifyingGlass,
       view: { type: 'search' } as AppView,
-      descriptionKey: 'search' as const
+      descriptionKey: 'search' as const,
     },
     { 
       id: 'print' as NavigationTab, 
@@ -79,8 +71,7 @@ export function NavigationMenu({ onNavigate, currentTab, isDarkMode }: Navigatio
     switch (key) {
       case 'home': return t.home.recentMemories;
       case 'prompts': return t.prompts.description;
-      case 'chapters': return t.chapters.description;
-      case 'timeline': return t.timeline.title;
+      case 'library': return t.chapters.description;
       case 'search': return t.search.title;
       case 'print': return t.print.description;
       default: return '';

--- a/src/components/screens/ChapterDetailScreen.tsx
+++ b/src/components/screens/ChapterDetailScreen.tsx
@@ -144,19 +144,21 @@ export function ChapterDetailScreen({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <div className="hidden sm:block">
+            <div className="hidden sm:block md:hidden">
               <NavigationMenu 
                 onNavigate={onNavigate} 
-                currentTab="chapters" 
+                currentTab="library" 
                 isDarkMode={isDarkMode} 
               />
             </div>
-            <SettingsPanel
-              themeMode={themeMode}
-              onThemeModeChange={setThemeMode}
-              isDarkMode={isDarkMode}
-              isNightTime={isNightTime}
-            />
+            <div className="md:hidden">
+              <SettingsPanel
+                themeMode={themeMode}
+                onThemeModeChange={setThemeMode}
+                isDarkMode={isDarkMode}
+                isNightTime={isNightTime}
+              />
+            </div>
           </div>
         </div>
       </header>

--- a/src/components/screens/ChaptersScreen.tsx
+++ b/src/components/screens/ChaptersScreen.tsx
@@ -98,19 +98,21 @@ export function ChaptersScreen({
               <span className="hidden sm:inline">{t.chapters.newChapter}</span>
               <span className="sm:hidden">New</span>
             </Button>
-            <div className="hidden sm:block">
+            <div className="hidden sm:block md:hidden">
               <NavigationMenu 
                 onNavigate={onNavigate} 
-                currentTab="chapters" 
+                currentTab="library" 
                 isDarkMode={isDarkMode} 
               />
             </div>
-            <SettingsPanel
-              themeMode={themeMode}
-              onThemeModeChange={setThemeMode}
-              isDarkMode={isDarkMode}
-              isNightTime={isNightTime}
-            />
+            <div className="md:hidden">
+              <SettingsPanel
+                themeMode={themeMode}
+                onThemeModeChange={setThemeMode}
+                isDarkMode={isDarkMode}
+                isNightTime={isNightTime}
+              />
+            </div>
           </div>
         </div>
       </header>

--- a/src/components/screens/EntryReadScreen.tsx
+++ b/src/components/screens/EntryReadScreen.tsx
@@ -145,19 +145,21 @@ export function EntryReadScreen({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <div className="hidden sm:block">
+            <div className="hidden sm:block md:hidden">
               <NavigationMenu 
                 onNavigate={onNavigate} 
                 currentTab="home" 
                 isDarkMode={isDarkMode} 
               />
             </div>
-            <SettingsPanel
-              themeMode={themeMode}
-              onThemeModeChange={setThemeMode}
-              isDarkMode={isDarkMode}
-              isNightTime={isNightTime}
-            />
+            <div className="md:hidden">
+              <SettingsPanel
+                themeMode={themeMode}
+                onThemeModeChange={setThemeMode}
+                isDarkMode={isDarkMode}
+                isNightTime={isNightTime}
+              />
+            </div>
           </div>
         </div>
       </header>

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import { Entry, Chapter, AppView, CHAPTER_ICONS, ChapterIcon } from '@/lib/types';
 import { getRecentEntries, getDraftEntry, getEntryTitle, formatShortDate } from '@/lib/entries';
 import { Button } from '@/components/ui/button';
-import { PencilSimple, Sparkle, Camera, Star, CaretRight, Books, NotePencil, X } from '@phosphor-icons/react';
+import { PencilSimple, Sparkle, Camera, Star, CaretRight, Books, NotePencil } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import { SettingsPanel } from '@/components/SettingsPanel';
 import { BrandHeader, CloudHeader } from '@/components/BrandHeader';
@@ -25,7 +25,6 @@ export function HomeScreen({
 }: HomeScreenProps) {
   const { t } = useLanguage();
   const { themeMode, setThemeMode, isDarkMode, isNightTime } = useTheme();
-  const [hasSeenWelcome, setHasSeenWelcome] = useLocalStorage<boolean>('tightly-has-seen-welcome', false);
   const [lastOTDToastDate, setLastOTDToastDate] = useLocalStorage<string>('tightly-last-otd-toast-date', '');
   
   const draft = getDraftEntry(entries);
@@ -139,16 +138,16 @@ export function HomeScreen({
 
   return (
     <div className="min-h-screen">
-      <header className="sticky top-0 z-10">
-        <CloudHeader isDarkMode={isDarkMode} className="mx-auto max-w-3xl px-4 pt-3">
-          <div className="flex items-center justify-between">
+      <header className="sticky top-0 z-10 w-full px-4 pt-3">
+        <CloudHeader isDarkMode={isDarkMode} className="w-full max-w-5xl mx-auto">
+          <div className="mx-auto max-w-3xl flex items-center justify-between">
             <BrandHeader isDarkMode={isDarkMode} />
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 md:hidden">
               <div className="hidden sm:block">
-                <NavigationMenu 
-                  onNavigate={onNavigate} 
-                  currentTab="home" 
-                  isDarkMode={isDarkMode} 
+                <NavigationMenu
+                  onNavigate={onNavigate}
+                  currentTab="home"
+                  isDarkMode={isDarkMode}
                 />
               </div>
               <SettingsPanel
@@ -163,148 +162,93 @@ export function HomeScreen({
       </header>
 
       <main className="max-w-3xl mx-auto px-4 py-6 space-y-6">
-        {/* Welcome Card - Show on first visit */}
-        {!hasSeenWelcome && !hasEntries && (
-          <motion.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="p-6 rounded-2xl bg-gradient-to-br from-primary/15 via-accent/10 to-primary/10 border border-primary/30 relative"
-          >
-            <button
-              onClick={() => setHasSeenWelcome(true)}
-              className="absolute top-3 right-3 p-1.5 rounded-lg hover:bg-background/50 transition-colors"
-            >
-              <X className="w-4 h-4 text-muted-foreground" />
-            </button>
-            <div className="mb-4">
-              <h2 className="font-serif text-2xl font-semibold text-foreground mb-2">
-                Welcome to Tightly ✨
-              </h2>
-              <p className="text-muted-foreground">
-                Your memories deserve to be more than forgotten moments. Let's create your first memory together.
-              </p>
-            </div>
-            <Button 
-              onClick={() => onNavigate({ type: 'prompts-new' })}
-              className="w-full sm:w-auto"
-            >
-              <Sparkle className="mr-2 w-4 h-4" weight="fill" />
-              Create My First Memory
-            </Button>
-          </motion.div>
-        )}
-
-        {/* Writing Streak Tracker */}
-        {hasEntries && (
-          <motion.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            className={`p-4 rounded-2xl border ${
-              writingStreak > 0
-                ? 'bg-gradient-to-br from-amber-500/10 via-orange-500/5 to-amber-500/10 border-amber-500/20'
-                : 'bg-accent/10 border-accent/20'
-            }`}
-          >
-            <div className="flex items-center gap-3">
+        {/* Unified hero: streak chip + primary + secondary action */}
+        <motion.section
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="p-5 sm:p-6 rounded-2xl bg-gradient-to-br from-primary/10 via-accent/5 to-primary/5 border border-primary/20"
+        >
+          {hasEntries && (
+            <div className="flex items-center gap-2 mb-4 text-sm">
               {writingStreak > 0 ? (
-                <>
-                  <div className="text-2xl">🔥</div>
-                  <div>
-                    <p className="font-medium text-foreground">
-                      {writingStreak} {writingStreak === 1 ? 'day' : 'days'} streak
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      Keep it going! Write today to continue your streak.
-                    </p>
-                  </div>
-                </>
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-700 dark:text-amber-400">
+                  <span>🔥</span>
+                  <span className="font-medium">
+                    {writingStreak} {writingStreak === 1 ? 'day' : 'days'}
+                  </span>
+                </span>
               ) : (
-                <>
-                  <div className="text-2xl">✨</div>
-                  <div>
-                    <p className="font-medium text-foreground">
-                      Start your streak today
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      Write consistently to build a writing habit.
-                    </p>
-                  </div>
-                </>
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-muted/40 border border-border/30 text-muted-foreground">
+                  <span>✨</span>
+                  <span className="text-xs">Start a streak today</span>
+                </span>
               )}
             </div>
-          </motion.div>
-        )}
+          )}
 
-        {draft && (
-          <motion.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="p-5 rounded-2xl bg-primary/10 border border-primary/20"
-          >
-            <div className="flex items-start gap-4">
-              <div className="p-3 rounded-xl bg-primary/20">
-                <PencilSimple weight="duotone" className="w-6 h-6 text-primary" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-muted-foreground mb-1">{t.home.continueWriting}</p>
-                <h3 className="font-serif text-lg font-semibold text-foreground truncate">
-                  {getEntryTitle(draft)}
-                </h3>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t.home.draft} · {t.home.lastEdited} {formatTimeAgo(draft.updated_at)}
-                </p>
-              </div>
-            </div>
-            <Button
-              onClick={() => onNavigate({ type: 'entry-edit', entryId: draft.id })}
-              className="w-full mt-4 shadow-md"
-            >
-              {t.home.continueWriting}
-            </Button>
-          </motion.div>
-        )}
-
-        {!draft && (
-          <motion.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="space-y-3"
-          >
-            <div className="grid grid-cols-2 gap-3">
-              <motion.button
-                onClick={() => onNavigate({ type: 'prompts-new' })}
-                className="p-4 rounded-2xl bg-gradient-to-br from-accent/15 via-primary/5 to-accent/10 border border-accent/25 hover:border-accent/40 transition-all text-left group"
-                whileTap={{ scale: 0.98 }}
-              >
-                <div className="p-2.5 rounded-xl bg-accent/20 w-fit mb-3">
-                  <NotePencil weight="duotone" className="w-5 h-5 text-accent" />
+          {draft ? (
+            <>
+              <div className="flex items-start gap-4 mb-4">
+                <div className="p-3 rounded-xl bg-primary/20 flex-shrink-0">
+                  <PencilSimple weight="duotone" className="w-6 h-6 text-primary" />
                 </div>
-                <h3 className="font-medium text-foreground group-hover:text-accent transition-colors text-sm">
-                  {t.home.customMemory}
-                </h3>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {t.home.customMemoryDesc}
-                </p>
-              </motion.button>
-
-              <motion.button
-                onClick={() => onNavigate({ type: 'prompts' })}
-                className="p-4 rounded-2xl bg-gradient-to-br from-primary/15 via-accent/5 to-primary/10 border border-primary/20 hover:border-primary/40 transition-all text-left group"
-                whileTap={{ scale: 0.98 }}
-              >
-                <div className="p-2.5 rounded-xl bg-primary/20 w-fit mb-3">
-                  <Sparkle weight="duotone" className="w-5 h-5 text-primary" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-muted-foreground mb-1">{t.home.continueWriting}</p>
+                  <h3 className="font-serif text-lg font-semibold text-foreground truncate">
+                    {getEntryTitle(draft)}
+                  </h3>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {t.home.draft} · {t.home.lastEdited} {formatTimeAgo(draft.updated_at)}
+                  </p>
                 </div>
-                <h3 className="font-medium text-foreground group-hover:text-primary transition-colors text-sm">
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Button
+                  onClick={() => onNavigate({ type: 'entry-edit', entryId: draft.id })}
+                  className="flex-1 shadow-md"
+                >
+                  {t.home.continueWriting}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => onNavigate({ type: 'prompts' })}
+                  className="flex-1"
+                >
+                  <Sparkle className="mr-2 w-4 h-4" weight="fill" />
                   {t.home.usePrompt}
-                </h3>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {t.home.usePromptDesc}
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="mb-4">
+                <h2 className="font-serif text-xl sm:text-2xl font-semibold text-foreground mb-1">
+                  {hasEntries ? t.home.newMemory : 'Welcome to Tightly ✨'}
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  {hasEntries ? t.home.customMemoryDesc : "Your memories deserve more than to be forgotten. Let's capture your first one."}
                 </p>
-              </motion.button>
-            </div>
-          </motion.div>
-        )}
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Button
+                  onClick={() => onNavigate({ type: 'prompts-new' })}
+                  className="flex-1 shadow-md"
+                >
+                  <NotePencil className="mr-2 w-4 h-4" weight="duotone" />
+                  {hasEntries ? t.home.customMemory : 'Create my first memory'}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => onNavigate({ type: 'prompts' })}
+                  className="flex-1"
+                >
+                  <Sparkle className="mr-2 w-4 h-4" weight="fill" />
+                  {t.home.usePrompt}
+                </Button>
+              </div>
+            </>
+          )}
+        </motion.section>
 
         {activeChapters.length > 0 && (
           <motion.section

--- a/src/components/screens/LibraryScreen.tsx
+++ b/src/components/screens/LibraryScreen.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { AppView, Entry, Chapter } from '@/lib/types';
+import { ChaptersScreen } from './ChaptersScreen';
+import { TimelineScreen } from './TimelineScreen';
+import { useLanguage } from '@/hooks/use-language.tsx';
+import { motion } from 'framer-motion';
+
+type LibraryTab = 'chapters' | 'timeline';
+
+interface LibraryScreenProps {
+  chapters: Chapter[];
+  entries: Entry[];
+  defaultTab?: LibraryTab;
+  onNavigate: (view: AppView) => void;
+  onSaveChapter: (chapter: Chapter) => void;
+  onDeleteChapter: (id: string) => void;
+}
+
+export function LibraryScreen({
+  chapters,
+  entries,
+  defaultTab = 'chapters',
+  onNavigate,
+  onSaveChapter,
+  onDeleteChapter,
+}: LibraryScreenProps) {
+  const { t } = useLanguage();
+  const [tab, setTab] = useState<LibraryTab>(defaultTab);
+
+  return (
+    <div className="relative">
+      {/* Segmented control overlayed above the active screen */}
+      <div className="sticky top-0 z-20 pointer-events-none">
+        <div className="max-w-3xl mx-auto px-4 pt-3 pointer-events-auto flex justify-center">
+          <div
+            role="tablist"
+            aria-label={t.nav.library}
+            className="inline-flex items-center gap-1 p-1 rounded-full bg-card/80 backdrop-blur-xl border border-border/30 shadow-sm"
+          >
+            {(['chapters', 'timeline'] as const).map((key) => {
+              const isActive = tab === key;
+              return (
+                <motion.button
+                  key={key}
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setTab(key)}
+                  whileTap={{ scale: 0.97 }}
+                  className={`relative px-4 py-1.5 text-sm font-medium rounded-full transition-colors ${
+                    isActive
+                      ? 'text-primary'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {isActive && (
+                    <motion.span
+                      layoutId="library-tab-active"
+                      className="absolute inset-0 rounded-full bg-primary/15 border border-primary/30"
+                      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                    />
+                  )}
+                  <span className="relative">{t.nav[key]}</span>
+                </motion.button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {tab === 'chapters' ? (
+        <ChaptersScreen
+          chapters={chapters}
+          entries={entries}
+          onNavigate={onNavigate}
+          onSaveChapter={onSaveChapter}
+          onDeleteChapter={onDeleteChapter}
+        />
+      ) : (
+        <TimelineScreen
+          entries={entries}
+          chapters={chapters}
+          onNavigate={onNavigate}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/screens/PrintScreen.tsx
+++ b/src/components/screens/PrintScreen.tsx
@@ -127,19 +127,21 @@ export function PrintScreen({
                 Print a Book
               </Button>
             )}
-            <div className="hidden sm:block">
+            <div className="hidden sm:block md:hidden">
               <NavigationMenu 
                 onNavigate={onNavigate} 
                 currentTab="print" 
                 isDarkMode={isDarkMode} 
               />
             </div>
-            <SettingsPanel
-              themeMode={themeMode}
-              onThemeModeChange={setThemeMode}
-              isDarkMode={isDarkMode}
-              isNightTime={isNightTime}
-            />
+            <div className="md:hidden">
+              <SettingsPanel
+                themeMode={themeMode}
+                onThemeModeChange={setThemeMode}
+                isDarkMode={isDarkMode}
+                isNightTime={isNightTime}
+              />
+            </div>
           </div>
         </div>
       </header>

--- a/src/components/screens/PromptsScreen.tsx
+++ b/src/components/screens/PromptsScreen.tsx
@@ -46,19 +46,21 @@ export function PromptsScreen({ onNavigate }: PromptsScreenProps) {
             <h1 className="font-serif text-lg sm:text-xl font-semibold text-foreground">{t.home.newMemory}</h1>
           </div>
           <div className="flex items-center gap-2">
-            <div className="hidden sm:block">
+            <div className="hidden sm:block md:hidden">
               <NavigationMenu 
                 onNavigate={onNavigate} 
                 currentTab="prompts" 
                 isDarkMode={isDarkMode} 
               />
             </div>
-            <SettingsPanel
-              themeMode={themeMode}
-              onThemeModeChange={setThemeMode}
-              isDarkMode={isDarkMode}
-              isNightTime={isNightTime}
-            />
+            <div className="md:hidden">
+              <SettingsPanel
+                themeMode={themeMode}
+                onThemeModeChange={setThemeMode}
+                isDarkMode={isDarkMode}
+                isNightTime={isNightTime}
+              />
+            </div>
           </div>
         </div>
       </header>

--- a/src/components/screens/SearchScreen.tsx
+++ b/src/components/screens/SearchScreen.tsx
@@ -50,19 +50,21 @@ export function SearchScreen({
               size="sm"
             />
             <div className="flex-1" />
-            <div className="hidden sm:block">
+            <div className="hidden sm:block md:hidden">
               <NavigationMenu 
                 onNavigate={onNavigate} 
-                currentTab="search" 
+                currentTab="home" 
                 isDarkMode={isDarkMode} 
               />
             </div>
-            <SettingsPanel
-              themeMode={themeMode}
-              onThemeModeChange={setThemeMode}
-              isDarkMode={isDarkMode}
-              isNightTime={isNightTime}
-            />
+            <div className="md:hidden">
+              <SettingsPanel
+                themeMode={themeMode}
+                onThemeModeChange={setThemeMode}
+                isDarkMode={isDarkMode}
+                isNightTime={isNightTime}
+              />
+            </div>
           </div>
           <div className="relative">
             <MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" weight="bold" />

--- a/src/components/screens/TimelineScreen.tsx
+++ b/src/components/screens/TimelineScreen.tsx
@@ -105,7 +105,9 @@ export function TimelineScreen({ entries, chapters, onNavigate }: TimelineScreen
               {t.timeline.title}
             </h1>
           </div>
-          <SettingsPanel />
+          <div className="md:hidden">
+            <SettingsPanel />
+          </div>
         </div>
       </div>
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -25,7 +25,7 @@ export function detectBrowserLanguage(): AppLanguage {
 }
 
 type TranslationKeys = {
-  nav: { home: string; prompts: string; chapters: string; timeline: string; search: string; print: string };
+  nav: { home: string; prompts: string; chapters: string; timeline: string; search: string; print: string; library: string };
   settings: { 
     title: string; description: string; language: string; languageDesc: string; autoDetect: string; autoDetectDesc: string;
     account: string; privacy: string; privacyDesc: string; exportData: string; exportDataDesc: string; 
@@ -78,7 +78,7 @@ type TranslationKeys = {
 
 const translations: Record<AppLanguage, TranslationKeys> = {
   en: {
-    nav: { home: 'Home', prompts: 'Prompts', chapters: 'Chapters', timeline: 'Timeline', search: 'Search', print: 'Print' },
+    nav: { home: 'Home', prompts: 'Prompts', chapters: 'Chapters', timeline: 'Timeline', search: 'Search', print: 'Print', library: 'Library' },
     settings: { 
       title: 'Profile & Settings', description: 'Manage your Tightly experience', 
       language: 'Language', languageDesc: 'App display language', autoDetect: 'Auto-detect', autoDetectDesc: 'Use browser/device language',
@@ -144,7 +144,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     time: { justNow: 'just now', minutesAgo: 'm ago', hoursAgo: 'h ago', daysAgo: 'd ago' }
   },
   de: {
-    nav: { home: 'Start', prompts: 'Impulse', chapters: 'Kapitel', timeline: 'Zeitachse', search: 'Suche', print: 'Drucken' },
+    nav: { home: 'Start', prompts: 'Impulse', chapters: 'Kapitel', timeline: 'Zeitachse', search: 'Suche', print: 'Drucken', library: 'Bibliothek' },
     settings: { 
       title: 'Profil & Einstellungen', description: 'Verwalte dein Tightly-Erlebnis', 
       language: 'Sprache', languageDesc: 'App-Anzeigesprache', autoDetect: 'Automatisch erkennen', autoDetectDesc: 'Browser-/Gerätesprache verwenden',
@@ -210,7 +210,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     time: { justNow: 'gerade eben', minutesAgo: 'min', hoursAgo: 'h', daysAgo: 'T' }
   },
   es: {
-    nav: { home: 'Inicio', prompts: 'Sugerencias', chapters: 'Capítulos', timeline: 'Cronología', search: 'Buscar', print: 'Imprimir' },
+    nav: { home: 'Inicio', prompts: 'Sugerencias', chapters: 'Capítulos', timeline: 'Cronología', search: 'Buscar', print: 'Imprimir', library: 'Biblioteca' },
     settings: { 
       title: 'Perfil y Ajustes', description: 'Gestiona tu experiencia Tightly', 
       language: 'Idioma', languageDesc: 'Idioma de la aplicación', autoDetect: 'Auto-detectar', autoDetectDesc: 'Usar idioma del navegador/dispositivo',
@@ -276,7 +276,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     time: { justNow: 'ahora mismo', minutesAgo: 'min', hoursAgo: 'h', daysAgo: 'd' }
   },
   fr: {
-    nav: { home: 'Accueil', prompts: 'Inspirations', chapters: 'Chapitres', timeline: 'Chronologie', search: 'Rechercher', print: 'Imprimer' },
+    nav: { home: 'Accueil', prompts: 'Inspirations', chapters: 'Chapitres', timeline: 'Chronologie', search: 'Rechercher', print: 'Imprimer', library: 'Bibliothèque' },
     settings: { 
       title: 'Profil & Paramètres', description: 'Gérez votre expérience Tightly', 
       language: 'Langue', languageDesc: "Langue d'affichage", autoDetect: 'Auto-détecter', autoDetectDesc: 'Utiliser la langue du navigateur/appareil',
@@ -342,7 +342,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     time: { justNow: 'à l\'instant', minutesAgo: 'min', hoursAgo: 'h', daysAgo: 'j' }
   },
   pt: {
-    nav: { home: 'Início', prompts: 'Sugestões', chapters: 'Capítulos', timeline: 'Linha do Tempo', search: 'Buscar', print: 'Imprimir' },
+    nav: { home: 'Início', prompts: 'Sugestões', chapters: 'Capítulos', timeline: 'Linha do Tempo', search: 'Buscar', print: 'Imprimir', library: 'Biblioteca' },
     settings: { 
       title: 'Perfil e Configurações', description: 'Gerencie sua experiência Tightly', 
       language: 'Idioma', languageDesc: 'Idioma do aplicativo', autoDetect: 'Auto-detectar', autoDetectDesc: 'Usar idioma do navegador/dispositivo',
@@ -408,7 +408,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     time: { justNow: 'agora mesmo', minutesAgo: 'min', hoursAgo: 'h', daysAgo: 'd' }
   },
   zh: {
-    nav: { home: '首页', prompts: '提示', chapters: '章节', timeline: '时间线', search: '搜索', print: '打印' },
+    nav: { home: '首页', prompts: '提示', chapters: '章节', timeline: '时间线', search: '搜索', print: '打印', library: '书库' },
     settings: { 
       title: '个人资料与设置', description: '管理您的Tightly体验', 
       language: '语言', languageDesc: '应用显示语言', autoDetect: '自动检测', autoDetectDesc: '使用浏览器/设备语言',
@@ -474,7 +474,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     time: { justNow: '刚刚', minutesAgo: '分钟前', hoursAgo: '小时前', daysAgo: '天前' }
   },
   ja: {
-    nav: { home: 'ホーム', prompts: 'プロンプト', chapters: 'チャプター', timeline: 'タイムライン', search: '検索', print: '印刷' },
+    nav: { home: 'ホーム', prompts: 'プロンプト', chapters: 'チャプター', timeline: 'タイムライン', search: '検索', print: '印刷', library: 'ライブラリ' },
     settings: { 
       title: 'プロフィールと設定', description: 'Tightly体験を管理', 
       language: '言語', languageDesc: 'アプリの表示言語', autoDetect: '自動検出', autoDetectDesc: 'ブラウザ/デバイスの言語を使用',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -169,7 +169,7 @@ export const DEFAULT_PROMPTS: Prompt[] = [
   { id: '16', text: 'What makes you feel most alive?', category: 'reflection' },
 ];
 
-export type NavigationTab = 'home' | 'prompts' | 'chapters' | 'timeline' | 'search' | 'print';
+export type NavigationTab = 'home' | 'prompts' | 'library' | 'print';
 
 export type AppView = 
   | { type: 'home' }
@@ -178,6 +178,7 @@ export type AppView =
   | { type: 'chapters' }
   | { type: 'chapter-detail'; chapterId: string }
   | { type: 'timeline' }
+  | { type: 'library'; tab?: 'chapters' | 'timeline' }
   | { type: 'entry-read'; entryId: string; returnTo?: AppView }
   | { type: 'entry-edit'; entryId: string; returnTo?: AppView }
   | { type: 'search' }


### PR DESCRIPTION
## Why
Three friction points on the current UI:
1. The cloud header didn't span the screen
2. Desktop had two overlapping nav surfaces (sidebar + in-header menu)
3. Information architecture was crowded (6 tabs, redundant hero blocks)

## What changed

**Nav dedup**
- `DesktopSidebar` is now the single desktop nav surface
- In-header `NavigationMenu` + `SettingsPanel` gated to `md:hidden` across all screens
- Mobile (≤ 640px) keeps `BottomNav`; tablets (640–767px) keep the hamburger

**Cloud header**
- Sticky header restructured so `FluffyCloudShape` spans the full content column (`max-w-5xl`), with an inner `max-w-3xl` for brand content

**Home hero**
- Merged Welcome + Streak + Draft + Quick-actions into one primary CTA cluster
- CTA adapts to draft vs. no-draft and first-run vs. returning user
- Removed the `hasSeenWelcome` dismissible card (onboarding tour handles first-run now)

**IA: 6 tabs → 4**
- New tabs: **Home · Prompts · Library · Print**
- New `LibraryScreen` wraps Chapters + Timeline under a segmented control
- Search promoted to a utility: ⌘K / Ctrl+K shortcut, sidebar icon button, mobile hamburger entry
- `chapters` / `timeline` / `search` views still resolve for deep-link back-compat

**i18n**
- Added `nav.library` translation for all 7 languages (en, de, es, fr, pt, zh, ja)

## Verification
- `npx tsc --noEmit` ✓ clean
- `npm run build` ✓
- `npm test` ✓ 20/20

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>