### PR TITLE
Switch body font to Raleway

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Tightly - Memory Journal</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600;9..40,700&family=Dancing+Script:wght@400;500;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&family=Raleway:wght@300;400;500;600;700&family=Dancing+Script:wght@400;500;600;700&display=swap">
     <link href="/src/main.css" rel="stylesheet" />
 </head>
 

--- a/src/index.css
+++ b/src/index.css
@@ -103,7 +103,7 @@
 }
 
 @theme {
-  --font-sans: 'DM Sans', system-ui, sans-serif;
+  --font-sans: 'Raleway', system-ui, sans-serif;
   --font-serif: 'Cormorant Garamond', Georgia, serif;
   --font-script: 'Dancing Script', cursive;
 


### PR DESCRIPTION
Swaps DM Sans → **Raleway** for body text across the app.

## Changes
- `index.html`: Google Fonts link now loads Raleway (300–700) instead of DM Sans
- `src/index.css`: `--font-sans` set to `'Raleway'`

## Kept as-is
- **Logo** (`BrandHeader.tsx`): still Dancing Script with the purple gradient — unchanged
- **Headings**: still Cormorant Garamond

If the purple script "tightly" logo isn't rendering, hard-reload the page — Google Fonts may not have loaded. The logo code hasn't changed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>