### PR TITLE
Add collaborative memory sharing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { useIsMobile } from './hooks/use-mobile';
 import { LanguageProvider } from './hooks/use-language.tsx';
 import { useJournalData } from './hooks/use-journal-data';
+import { canEditEntry } from './lib/entries';
 import { motion, AnimatePresence } from 'framer-motion';
 import { supabase } from './lib/supabase';
 
@@ -42,7 +43,7 @@ const EntryEditScreen = lazy(() =>
 );
 
 function AppContent() {
-  const { session, loading: authLoading, isPasswordRecovery } = useAuth();
+  const { session, user, loading: authLoading, isPasswordRecovery } = useAuth();
   const [currentView, setCurrentView] = useState<AppView>({ type: 'home' });
   const { isDarkMode, isNightTime, themeMode, setThemeMode } = useTheme();
   const isMobile = useIsMobile();
@@ -57,6 +58,9 @@ function AppContent() {
     saveChapter,
     deleteChapter,
     assignChapter,
+    inviteCollaborator,
+    updateCollaboratorRole,
+    removeCollaborator,
     saveBook,
     deleteBook,
   } = useJournalData();
@@ -234,7 +238,7 @@ function AppContent() {
         );
       }
 
-      case 'chapter-detail':
+      case 'chapter-detail': {
         const chapter = chapters.find(c => c.id === currentView.chapterId);
         if (!chapter) {
           navigate({ type: 'library' });
@@ -250,8 +254,9 @@ function AppContent() {
             onToggleStar={toggleStar}
           />
         );
+      }
 
-      case 'entry-read':
+      case 'entry-read': {
         const readEntry = entries.find(e => e.id === currentView.entryId);
         if (!readEntry) {
           navigate({ type: 'home' });
@@ -262,26 +267,37 @@ function AppContent() {
             entry={readEntry}
             chapter={chapters.find(c => c.id === readEntry.chapter_id) || null}
             onNavigate={navigate}
+            currentUserId={user?.id}
+            currentUserEmail={user?.email}
             onToggleStar={() => toggleStar(readEntry.id)}
             onDelete={() => {
               deleteEntry(readEntry.id);
               navigate({ type: 'home' });
             }}
             onAssignChapter={(chapterId) => assignChapter(readEntry.id, chapterId)}
+            onInviteCollaborator={(email, role) => inviteCollaborator(readEntry.id, email, role)}
+            onUpdateCollaboratorRole={updateCollaboratorRole}
+            onRemoveCollaborator={removeCollaborator}
             chapters={chapters}
           />
         );
+      }
 
-      case 'entry-edit':
+      case 'entry-edit': {
         const editEntry = entries.find(e => e.id === currentView.entryId);
         if (!editEntry) {
           navigate({ type: 'home' });
+          return null;
+        }
+        if (!canEditEntry(editEntry, user?.id)) {
+          navigate({ type: 'entry-read', entryId: editEntry.id });
           return null;
         }
         return (
           <EntryEditScreen
             entry={editEntry}
             chapters={chapters}
+            currentUserId={user?.id}
             onSave={(entry) => {
               saveEntry(entry);
               if (!entry.is_draft) {
@@ -297,6 +313,7 @@ function AppContent() {
             onSaveChapter={saveChapter}
           />
         );
+      }
 
       case 'search':
         return (

--- a/src/components/entry/CollaboratorsDialog.tsx
+++ b/src/components/entry/CollaboratorsDialog.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { Users, X } from '@phosphor-icons/react';
+import { toast } from 'sonner';
+import { Entry, EntryCollaborator, EntryCollaboratorRole } from '@/lib/types';
+import { getEntryTitle } from '@/lib/entries';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+interface CollaboratorsDialogProps {
+  entry: Entry;
+  open: boolean;
+  currentUserEmail?: string | null;
+  onOpenChange: (open: boolean) => void;
+  onInvite: (email: string, role: EntryCollaboratorRole) => void;
+  onUpdateRole: (collaboratorId: string, role: EntryCollaboratorRole) => void;
+  onRemove: (collaboratorId: string) => void;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function initials(email: string): string {
+  return email.slice(0, 2).toUpperCase();
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function getCollaboratorLabel(collaborator: EntryCollaborator): string {
+  return collaborator.status === 'pending'
+    ? 'Pending'
+    : collaborator.role === 'editor'
+      ? 'Can edit'
+      : 'Can view';
+}
+
+export function CollaboratorsDialog({
+  entry,
+  open,
+  currentUserEmail,
+  onOpenChange,
+  onInvite,
+  onUpdateRole,
+  onRemove,
+}: CollaboratorsDialogProps) {
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<EntryCollaboratorRole>('editor');
+  const collaborators = entry.collaborators ?? [];
+  const ownerEmail = currentUserEmail && entry.collaboration_role === 'owner'
+    ? currentUserEmail
+    : 'Memory owner';
+
+  const handleInvite = () => {
+    const normalized = normalizeEmail(email);
+    if (!EMAIL_PATTERN.test(normalized)) {
+      toast.error('Enter a valid email address.');
+      return;
+    }
+
+    if (currentUserEmail && normalized === normalizeEmail(currentUserEmail)) {
+      toast.error('You already own this memory.');
+      return;
+    }
+
+    if (collaborators.some(c => normalizeEmail(c.invitee_email) === normalized)) {
+      toast.error('This person is already invited.');
+      return;
+    }
+
+    onInvite(normalized, role);
+    setEmail('');
+    setRole('editor');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Users weight="duotone" className="w-5 h-5 text-primary" />
+            Collaborate on this memory
+          </DialogTitle>
+          <DialogDescription>
+            Invite someone to remember and write “{getEntryTitle(entry)}” together.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          {entry.collaboration_role === 'owner' && (
+            <div className="rounded-xl border border-border/60 bg-muted/20 p-3">
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  placeholder="friend@example.com"
+                  className="flex-1"
+                />
+                <Select value={role} onValueChange={(value) => setRole(value as EntryCollaboratorRole)}>
+                  <SelectTrigger className="sm:w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="editor">Can edit</SelectItem>
+                    <SelectItem value="viewer">Can view</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button onClick={handleInvite}>Send invite</Button>
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                They will need to sign in with this email.
+              </p>
+            </div>
+          )}
+
+          <div className="space-y-3">
+            <CollaboratorRow
+              email={ownerEmail}
+              label="Owner"
+              badgeVariant="default"
+            />
+
+            {collaborators.map((collaborator) => (
+              <CollaboratorRow
+                key={collaborator.id}
+                email={collaborator.invitee_email}
+                label={getCollaboratorLabel(collaborator)}
+                badgeVariant={collaborator.status === 'pending' ? 'outline' : 'secondary'}
+                role={collaborator.role}
+                canManage={entry.collaboration_role === 'owner'}
+                onRoleChange={(nextRole) => onUpdateRole(collaborator.id, nextRole)}
+                onRemove={() => onRemove(collaborator.id)}
+              />
+            ))}
+          </div>
+
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Editors can update the title, notes, story, tags, date, and chapter. Only the owner can delete the memory,
+            manage collaborators, or manage photos for now.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CollaboratorRow({
+  email,
+  label,
+  badgeVariant,
+  role,
+  canManage = false,
+  onRoleChange,
+  onRemove,
+}: {
+  email: string;
+  label: string;
+  badgeVariant: 'default' | 'secondary' | 'outline';
+  role?: EntryCollaboratorRole;
+  canManage?: boolean;
+  onRoleChange?: (role: EntryCollaboratorRole) => void;
+  onRemove?: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border/50 p-3">
+      <Avatar className="h-9 w-9">
+        <AvatarFallback className="text-xs font-semibold">
+          {initials(email)}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">{email}</p>
+        <Badge variant={badgeVariant} className="mt-1">
+          {label}
+        </Badge>
+      </div>
+      {canManage && role && onRoleChange && (
+        <Select value={role} onValueChange={(value) => onRoleChange(value as EntryCollaboratorRole)}>
+          <SelectTrigger className="w-28">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="editor">Can edit</SelectItem>
+            <SelectItem value="viewer">Can view</SelectItem>
+          </SelectContent>
+        </Select>
+      )}
+      {canManage && onRemove && (
+        <Button variant="ghost" size="icon" onClick={onRemove} aria-label={`Remove ${email}`}>
+          <X className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/screens/EntryEditScreen.tsx
+++ b/src/components/screens/EntryEditScreen.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Entry, Photo, Chapter, StoryTone, STORY_TONES, STORY_LANGUAGES, DEFAULT_PROMPTS, CHAPTER_ICONS, CHAPTER_COLORS, ChapterIcon, AppView } from '@/lib/types';
-import { createEmptyEntry, generateAIContent, formatDate, getEntryTitle } from '@/lib/entries';
+import { createEmptyEntry, generateAIContent, formatDate, canManageEntryPhotos, isEntryOwner } from '@/lib/entries';
 import { RateLimitError, formatRetryAfter } from '@/lib/ai-quota';
 import { searchLocations, getCurrentLocation, GeocodingResult, GeocodingServiceError } from '@/lib/geocoding';
 import { Button } from '@/components/ui/button';
@@ -33,9 +33,7 @@ import {
   House,
   Trash,
   Plus,
-  ArrowsClockwise,
   CircleNotch,
-  Check,
   CaretDown,
   CaretUp,
   PencilSimple
@@ -48,7 +46,6 @@ import { AudioWaveform } from '@/components/entry/AudioWaveform';
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { motion, AnimatePresence } from 'framer-motion';
 import { LogoHomeButton } from '@/components/LogoHomeButton';
-import { useLanguage } from '@/hooks/use-language.tsx';
 import { useAuth } from '@/contexts/AuthContext';
 import { uploadEntryPhoto, getSignedPhotoUrl } from '@/lib/photos';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -88,6 +85,7 @@ interface EntryEditScreenProps {
   onDelete?: () => void;
   onNavigate?: (view: AppView) => void;
   onSaveChapter?: (chapter: Chapter) => void;
+  currentUserId?: string;
 }
 
 export function EntryEditScreen({ 
@@ -98,13 +96,15 @@ export function EntryEditScreen({
   onBack, 
   onDelete,
   onNavigate,
-  onSaveChapter
+  onSaveChapter,
+  currentUserId
 }: EntryEditScreenProps) {
   const { isDarkMode } = useTheme();
-  const { t, language } = useLanguage();
   const { user } = useAuth();
   const isMobile = useIsMobile();
   const isNewEntry = !entry;
+  const canManagePhotos = !entry || canManageEntryPhotos(entry, currentUserId);
+  const editingAsCollaborator = !!entry && !isEntryOwner(entry, currentUserId);
   const prompt = promptId ? DEFAULT_PROMPTS.find(p => p.id === promptId) : null;
 
   // Stable id for this editing session — used as the storage path segment for
@@ -148,11 +148,11 @@ export function EntryEditScreen({
   const [isDragging, setIsDragging] = useState(false);
   const [locationQuery, setLocationQuery] = useState('');
   const [locationResults, setLocationResults] = useState<GeocodingResult[]>([]);
-  const [isSearchingLocation, setIsSearchingLocation] = useState(false);
+  const [, setIsSearchingLocation] = useState(false);
   const [showLocationDropdown, setShowLocationDropdown] = useState(false);
   const [isGettingLocation, setIsGettingLocation] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [lastAutoSaveTime, setLastAutoSaveTime] = useState<Date | null>(null);
+  const [, setLastAutoSaveTime] = useState<Date | null>(null);
   const [showSavedIndicator, setShowSavedIndicator] = useState(false);
   const [isUnsavedChangesDialogOpen, setIsUnsavedChangesDialogOpen] = useState(false);
   
@@ -344,6 +344,10 @@ export function EntryEditScreen({
   };
 
   const processImageFiles = useCallback((files: File[]) => {
+    if (!canManagePhotos) {
+      toast.error('Only the owner can manage photos for now.');
+      return;
+    }
     const imageFiles = files.filter(file => file.type.startsWith('image/'));
     if (imageFiles.length === 0) return;
     if (!user) {
@@ -383,12 +387,12 @@ export function EntryEditScreen({
       const uploaded = results.filter((p): p is Photo => p !== null);
       if (uploaded.length) setPhotos(prev => [...prev, ...uploaded]);
     });
-  }, [photos.length, user]);
+  }, [canManagePhotos, photos.length, user]);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-    if (photos.length < 10) setIsDragging(true);
-  }, [photos.length]);
+    if (canManagePhotos && photos.length < 10) setIsDragging(true);
+  }, [canManagePhotos, photos.length]);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -400,9 +404,9 @@ export function EntryEditScreen({
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(false);
-    if (photos.length >= 10) return;
+    if (!canManagePhotos || photos.length >= 10) return;
     processImageFiles(Array.from(e.dataTransfer.files));
-  }, [photos.length, processImageFiles]);
+  }, [canManagePhotos, photos.length, processImageFiles]);
 
   // Helper functions to get selected items
   const getSelectedHighlights = (): string[] => {
@@ -648,6 +652,16 @@ export function EntryEditScreen({
           </div>
           <div className="flex items-center gap-2">
             <AnimatePresence>
+              {editingAsCollaborator && (
+                <motion.div
+                  initial={{ opacity: 0, x: -8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -8 }}
+                  className="hidden sm:flex text-xs text-muted-foreground items-center rounded-full bg-muted/60 px-2 py-1"
+                >
+                  Editing as collaborator
+                </motion.div>
+              )}
               {showSavedIndicator && (
                 <motion.div
                   initial={{ opacity: 0, x: -8 }}
@@ -743,7 +757,7 @@ export function EntryEditScreen({
             <label className="text-xs font-medium text-muted-foreground">
               📷 {photos.length} of 10 photos
             </label>
-            {photos.length < 10 && (
+            {canManagePhotos && photos.length < 10 && (
               <span className="text-xs text-muted-foreground">
                 {10 - photos.length} remaining
               </span>
@@ -758,9 +772,9 @@ export function EntryEditScreen({
               if (e.target.files) {
                 const fileCount = Array.from(e.target.files).length;
                 processImageFiles(Array.from(e.target.files));
-                if (fileCount > 0) {
-                  toast.success(`Added ${fileCount} ${fileCount === 1 ? 'photo' : 'photos'} ✨`);
-                }
+                  if (canManagePhotos && fileCount > 0) {
+                    toast.success(`Added ${fileCount} ${fileCount === 1 ? 'photo' : 'photos'} ✨`);
+                  }
               }
             }}
             className="hidden"
@@ -777,18 +791,20 @@ export function EntryEditScreen({
                   className="relative aspect-square group rounded-xl overflow-hidden"
                 >
                   <img src={photo.storage_url} alt="" className="w-full h-full object-cover" />
-                  <button
-                    onClick={() => setPhotos(prev => prev.filter(p => p.id !== photo.id))}
-                    className="absolute top-1 right-1 p-1 bg-black/50 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
-                  >
-                    <X className="w-3 h-3 text-white" />
-                  </button>
+                  {canManagePhotos && (
+                    <button
+                      onClick={() => setPhotos(prev => prev.filter(p => p.id !== photo.id))}
+                      className="absolute top-1 right-1 p-1 bg-black/50 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <X className="w-3 h-3 text-white" />
+                    </button>
+                  )}
                 </motion.div>
               ))}
             </div>
           )}
 
-          {photos.length < 10 && (
+          {canManagePhotos && photos.length < 10 && (
             <div className="flex gap-2">
               <button
                 onClick={() => fileInputRef.current?.click()}
@@ -803,6 +819,11 @@ export function EntryEditScreen({
                 </p>
               </button>
             </div>
+          )}
+          {!canManagePhotos && (
+            <p className="text-xs text-muted-foreground mt-2">
+              Only the owner can manage photos for now.
+            </p>
           )}
         </div>
 

--- a/src/components/screens/EntryReadScreen.tsx
+++ b/src/components/screens/EntryReadScreen.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Entry, Chapter, AppView, CHAPTER_ICONS, ChapterIcon } from '@/lib/types';
-import { getEntryTitle, formatDate } from '@/lib/entries';
+import { Entry, Chapter, AppView, CHAPTER_ICONS, ChapterIcon, EntryCollaboratorRole } from '@/lib/types';
+import { getEntryTitle, formatDate, canEditEntry, canManageEntryCollaborators } from '@/lib/entries';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { 
@@ -20,15 +20,16 @@ import {
   Trash,
   FolderSimple,
   MapPin,
-  Tag
+  Tag,
+  Users
 } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import { toast } from 'sonner';
 import { SettingsPanel } from '@/components/SettingsPanel';
 import { LogoHomeButton } from '@/components/LogoHomeButton';
 import { NavigationMenu } from '@/components/navigation/NavigationMenu';
-import { useLanguage } from '@/hooks/use-language.tsx';
 import { useTheme } from '@/contexts/ThemeContext';
+import { CollaboratorsDialog } from '@/components/entry/CollaboratorsDialog';
 
 interface EntryReadScreenProps {
   entry: Entry;
@@ -38,6 +39,11 @@ interface EntryReadScreenProps {
   onToggleStar: () => void;
   onDelete: () => void;
   onAssignChapter: (chapterId: string | null) => void;
+  currentUserId?: string;
+  currentUserEmail?: string | null;
+  onInviteCollaborator: (email: string, role: EntryCollaboratorRole) => void;
+  onUpdateCollaboratorRole: (collaboratorId: string, role: EntryCollaboratorRole) => void;
+  onRemoveCollaborator: (collaboratorId: string) => void;
 }
 
 export function EntryReadScreen({
@@ -47,15 +53,24 @@ export function EntryReadScreen({
   onNavigate,
   onToggleStar,
   onDelete,
-  onAssignChapter
+  onAssignChapter,
+  currentUserId,
+  currentUserEmail,
+  onInviteCollaborator,
+  onUpdateCollaboratorRole,
+  onRemoveCollaborator
 }: EntryReadScreenProps) {
   const { themeMode, setThemeMode, isDarkMode, isNightTime } = useTheme();
-  const { t } = useLanguage();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+  const [isCollaboratorsDialogOpen, setIsCollaboratorsDialogOpen] = useState(false);
 
   const title = getEntryTitle(entry);
   const location = entry.tags_ai?.places?.[0] || entry.manual_locations?.[0];
+  const editable = canEditEntry(entry, currentUserId);
+  const canManageCollaborators = canManageEntryCollaborators(entry, currentUserId);
+  const collaborators = entry.collaborators ?? [];
+  const isShared = collaborators.length > 0 || (!!entry.collaboration_role && entry.collaboration_role !== 'owner');
 
   const getIconEmoji = (icon: ChapterIcon) => 
     CHAPTER_ICONS.find(i => i.value === icon)?.emoji || '📁';
@@ -108,13 +123,19 @@ export function EntryReadScreen({
           </div>
           
           <div className="flex items-center gap-1">
-            <Button 
-              onClick={() => onNavigate({ type: 'entry-edit', entryId: entry.id })}
-              size="sm"
-            >
-              <PencilSimple className="mr-1.5 w-4 h-4" weight="bold" />
-              Edit
-            </Button>
+            {editable ? (
+              <Button 
+                onClick={() => onNavigate({ type: 'entry-edit', entryId: entry.id })}
+                size="sm"
+              >
+                <PencilSimple className="mr-1.5 w-4 h-4" weight="bold" />
+                Edit
+              </Button>
+            ) : (
+              <Button variant="outline" size="sm" disabled>
+                View only
+              </Button>
+            )}
             
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -123,26 +144,38 @@ export function EntryReadScreen({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem onClick={onToggleStar}>
-                  <Star className="mr-2 w-4 h-4" weight={entry.is_starred ? 'fill' : 'regular'} />
-                  {entry.is_starred ? 'Remove star' : 'Star'}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setIsMoveDialogOpen(true)}>
-                  <FolderSimple className="mr-2 w-4 h-4" />
-                  Move to chapter
+                {editable && (
+                  <>
+                    <DropdownMenuItem onClick={onToggleStar}>
+                      <Star className="mr-2 w-4 h-4" weight={entry.is_starred ? 'fill' : 'regular'} />
+                      {entry.is_starred ? 'Remove star' : 'Star'}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setIsMoveDialogOpen(true)}>
+                      <FolderSimple className="mr-2 w-4 h-4" />
+                      Move to chapter
+                    </DropdownMenuItem>
+                  </>
+                )}
+                <DropdownMenuItem onClick={() => setIsCollaboratorsDialogOpen(true)}>
+                  <Users className="mr-2 w-4 h-4" />
+                  {canManageCollaborators ? 'Invite collaborators' : 'View collaborators'}
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={handleShare}>
                   <ShareNetwork className="mr-2 w-4 h-4" />
-                  Share
+                  Share text
                 </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem 
-                  onClick={() => setIsDeleteDialogOpen(true)}
-                  className="text-destructive focus:text-destructive"
-                >
-                  <Trash className="mr-2 w-4 h-4" />
-                  Delete
-                </DropdownMenuItem>
+                {canManageCollaborators && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem 
+                      onClick={() => setIsDeleteDialogOpen(true)}
+                      className="text-destructive focus:text-destructive"
+                    >
+                      <Trash className="mr-2 w-4 h-4" />
+                      Delete
+                    </DropdownMenuItem>
+                  </>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
             <div className="hidden sm:block md:hidden">
@@ -227,6 +260,16 @@ export function EntryReadScreen({
               {chapter && (
                 <span className="text-sm text-muted-foreground flex items-center gap-1">
                   {getIconEmoji(chapter.icon)} {chapter.name}
+                </span>
+              )}
+              {isShared && (
+                <span className="text-sm text-muted-foreground flex items-center gap-1">
+                  <Users weight="duotone" className="w-4 h-4" />
+                  {entry.collaboration_role === 'owner'
+                    ? `Shared with ${collaborators.length}`
+                    : entry.collaboration_role === 'editor'
+                      ? 'Can edit'
+                      : 'View only'}
                 </span>
               )}
               {entry.is_starred && (
@@ -344,6 +387,16 @@ export function EntryReadScreen({
           </div>
         </DialogContent>
       </Dialog>
+
+      <CollaboratorsDialog
+        entry={entry}
+        open={isCollaboratorsDialogOpen}
+        currentUserEmail={currentUserEmail}
+        onOpenChange={setIsCollaboratorsDialogOpen}
+        onInvite={onInviteCollaborator}
+        onUpdateRole={onUpdateCollaboratorRole}
+        onRemove={onRemoveCollaborator}
+      />
     </div>
   );
 }

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import { Entry, Chapter, AppView, CHAPTER_ICONS, ChapterIcon } from '@/lib/types';
 import { getRecentEntries, getDraftEntry, getEntryTitle, formatShortDate } from '@/lib/entries';
 import { Button } from '@/components/ui/button';
-import { PencilSimple, Sparkle, Camera, Star, CaretRight, Books, NotePencil } from '@phosphor-icons/react';
+import { PencilSimple, Sparkle, Camera, Star, CaretRight, Books, NotePencil, Users } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import { SettingsPanel } from '@/components/SettingsPanel';
 import { BrandHeader, CloudHeader } from '@/components/BrandHeader';
@@ -445,6 +445,9 @@ export function HomeScreen({
                         </h3>
                         {entry.is_starred && (
                           <Star weight="fill" className="w-4 h-4 text-amber-400 flex-shrink-0" />
+                        )}
+                        {((entry.collaborators?.length ?? 0) > 0 || (!!entry.collaboration_role && entry.collaboration_role !== 'owner')) && (
+                          <Users weight="duotone" className="w-4 h-4 text-primary/70 flex-shrink-0" />
                         )}
                       </div>
                       <p className="text-sm text-muted-foreground">

--- a/src/hooks/use-journal-data.ts
+++ b/src/hooks/use-journal-data.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/lib/supabase';
-import { Entry, Chapter, Book } from '@/lib/types';
+import { Entry, Chapter, Book, EntryCollaboratorRole } from '@/lib/types';
 import * as db from '@/lib/db';
 
 /*
@@ -29,7 +29,7 @@ export function useJournalData() {
 
   const entriesQuery = useQuery({
     queryKey: entriesKey,
-    queryFn: () => db.fetchEntries(userId!),
+    queryFn: () => db.fetchEntries(userId!, user?.email),
     enabled,
     staleTime: STALE_TIME,
   });
@@ -126,6 +126,40 @@ export function useJournalData() {
     onError: (_e, _v, ctx) => {
       if (ctx?.prev) qc.setQueryData(entriesKey, ctx.prev);
       toast.error('Failed to assign chapter. Please try again.');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
+  });
+
+  const inviteCollaboratorMutation = useMutation({
+    mutationFn: async ({ entryId, email, role }: { entryId: string; email: string; role: EntryCollaboratorRole }) => {
+      if (!userId) throw new Error('Not signed in');
+      await db.inviteEntryCollaborator(userId, entryId, email, role);
+    },
+    onSuccess: () => {
+      toast.success('Collaborator invited');
+    },
+    onError: () => {
+      toast.error('Failed to invite collaborator. Please try again.');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
+  });
+
+  const updateCollaboratorRoleMutation = useMutation({
+    mutationFn: ({ collaboratorId, role }: { collaboratorId: string; role: EntryCollaboratorRole }) =>
+      db.updateEntryCollaboratorRole(collaboratorId, role),
+    onError: () => {
+      toast.error('Failed to update collaborator role. Please try again.');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
+  });
+
+  const removeCollaboratorMutation = useMutation({
+    mutationFn: (collaboratorId: string) => db.removeEntryCollaborator(collaboratorId),
+    onSuccess: () => {
+      toast.success('Collaborator removed');
+    },
+    onError: () => {
+      toast.error('Failed to remove collaborator. Please try again.');
     },
     onSettled: () => qc.invalidateQueries({ queryKey: entriesKey }),
   });
@@ -250,6 +284,11 @@ export function useJournalData() {
     reorderChapters,
     assignChapter: (entryId: string, chapterId: string | null) =>
       assignChapterMutation.mutate({ entryId, chapterId }),
+    inviteCollaborator: (entryId: string, email: string, role: EntryCollaboratorRole) =>
+      inviteCollaboratorMutation.mutate({ entryId, email, role }),
+    updateCollaboratorRole: (collaboratorId: string, role: EntryCollaboratorRole) =>
+      updateCollaboratorRoleMutation.mutate({ collaboratorId, role }),
+    removeCollaborator: (collaboratorId: string) => removeCollaboratorMutation.mutate(collaboratorId),
     saveBook: (book: Book) => saveBookMutation.mutate(book),
     deleteBook: (bookId: string) => deleteBookMutation.mutate(bookId),
   };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,16 @@
 import { supabase } from './supabase';
-import { Entry, Chapter, Book, Photo, LocationSuggestion, ChapterIcon, BookTheme } from './types';
+import {
+  Entry,
+  Chapter,
+  Book,
+  Photo,
+  LocationSuggestion,
+  ChapterIcon,
+  BookTheme,
+  EntryAccessRole,
+  EntryCollaborator,
+  EntryCollaboratorRole,
+} from './types';
 import { getSignedPhotoUrls, deletePhotos } from './photos';
 
 /*
@@ -38,6 +49,18 @@ interface EntryRow {
   updated_at: string;
 }
 
+interface EntryCollaboratorRow {
+  id: string;
+  entry_id: string;
+  owner_id: string;
+  collaborator_user_id: string | null;
+  invitee_email: string;
+  role: EntryCollaboratorRole;
+  status: EntryCollaborator['status'];
+  created_at: string;
+  updated_at: string;
+}
+
 interface PhotoRow {
   id: string;
   entry_id: string;
@@ -49,9 +72,30 @@ interface PhotoRow {
   created_at: string;
 }
 
-function rowToEntry(row: EntryRow, photos: Photo[]): Entry {
+function rowToCollaborator(row: EntryCollaboratorRow): EntryCollaborator {
   return {
     id: row.id,
+    entry_id: row.entry_id,
+    owner_id: row.owner_id,
+    collaborator_user_id: row.collaborator_user_id,
+    invitee_email: row.invitee_email,
+    role: row.role,
+    status: row.status,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function getAccessRole(row: EntryRow, userId: string, collaborators: EntryCollaborator[]): EntryAccessRole {
+  if (row.user_id === userId) return 'owner';
+  const match = collaborators.find(c => c.collaborator_user_id === userId);
+  return match?.role ?? 'viewer';
+}
+
+function rowToEntry(row: EntryRow, photos: Photo[], collaborators: EntryCollaborator[], userId: string): Entry {
+  return {
+    id: row.id,
+    user_id: row.user_id,
     date: row.memory_date ?? row.created_at.slice(0, 10),
     title_user: row.title_user,
     title_ai: row.title_ai,
@@ -68,6 +112,8 @@ function rowToEntry(row: EntryRow, photos: Photo[]): Entry {
     is_draft: row.is_draft,
     chapter_id: row.chapter_id,
     photos,
+    collaborators,
+    collaboration_role: getAccessRole(row, userId, collaborators),
     prompt_used: row.prompt_used,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -77,7 +123,7 @@ function rowToEntry(row: EntryRow, photos: Photo[]): Entry {
 function entryToRow(userId: string, entry: Entry) {
   return {
     id: entry.id,
-    user_id: userId,
+    user_id: entry.user_id ?? userId,
     chapter_id: entry.chapter_id,
     memory_date: entry.date ? entry.date.slice(0, 10) : null,
     title_user: entry.title_user,
@@ -101,17 +147,33 @@ function entryToRow(userId: string, entry: Entry) {
 // Entries
 // ---------------------------------------------------------------------------
 
-export async function fetchEntries(userId: string): Promise<Entry[]> {
+export async function fetchEntries(userId: string, userEmail?: string | null): Promise<Entry[]> {
   const sb = assertSupabase();
-  const [entriesRes, photosRes] = await Promise.all([
-    sb.from('entries').select('*').eq('user_id', userId).order('memory_date', { ascending: false, nullsFirst: false }),
-    sb.from('entry_photos').select('*').eq('user_id', userId).order('position', { ascending: true }),
-  ]);
+  if (userEmail) {
+    const { error } = await sb.rpc('claim_entry_collaborator_invites', { p_email: userEmail });
+    if (error) throw error;
+  }
+
+  const entriesRes = await sb
+    .from('entries')
+    .select('*')
+    .order('memory_date', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false });
   if (entriesRes.error) throw entriesRes.error;
+
+  const entryIds = ((entriesRes.data ?? []) as EntryRow[]).map(row => row.id);
+  if (entryIds.length === 0) return [];
+
+  const [photosRes, collaboratorsRes] = await Promise.all([
+    sb.from('entry_photos').select('*').in('entry_id', entryIds).order('position', { ascending: true }),
+    sb.from('entry_collaborators').select('*').in('entry_id', entryIds).order('created_at', { ascending: true }),
+  ]);
   if (photosRes.error) throw photosRes.error;
+  if (collaboratorsRes.error) throw collaboratorsRes.error;
 
   const photoRows = (photosRes.data ?? []) as PhotoRow[];
   const signed = await getSignedPhotoUrls(photoRows.map(p => p.storage_path));
+  const collaboratorRows = (collaboratorsRes.data ?? []) as EntryCollaboratorRow[];
 
   const photosByEntry = new Map<string, Photo[]>();
   for (const row of photoRows) {
@@ -129,8 +191,15 @@ export async function fetchEntries(userId: string): Promise<Entry[]> {
     photosByEntry.set(row.entry_id, list);
   }
 
+  const collaboratorsByEntry = new Map<string, EntryCollaborator[]>();
+  for (const row of collaboratorRows) {
+    const list = collaboratorsByEntry.get(row.entry_id) ?? [];
+    list.push(rowToCollaborator(row));
+    collaboratorsByEntry.set(row.entry_id, list);
+  }
+
   return (entriesRes.data as EntryRow[]).map(row =>
-    rowToEntry(row, photosByEntry.get(row.id) ?? [])
+    rowToEntry(row, photosByEntry.get(row.id) ?? [], collaboratorsByEntry.get(row.id) ?? [], userId)
   );
 }
 
@@ -201,6 +270,42 @@ export async function setEntryStar(entryId: string, starred: boolean): Promise<v
 export async function setEntryChapter(entryId: string, chapterId: string | null): Promise<void> {
   const sb = assertSupabase();
   const { error } = await sb.from('entries').update({ chapter_id: chapterId }).eq('id', entryId);
+  if (error) throw error;
+}
+
+export async function inviteEntryCollaborator(
+  ownerId: string,
+  entryId: string,
+  inviteeEmail: string,
+  role: EntryCollaboratorRole
+): Promise<EntryCollaborator> {
+  const sb = assertSupabase();
+  const { data, error } = await sb
+    .from('entry_collaborators')
+    .insert({
+      entry_id: entryId,
+      owner_id: ownerId,
+      invitee_email: inviteeEmail.trim().toLowerCase(),
+      role,
+    })
+    .select('*')
+    .single();
+  if (error) throw error;
+  return rowToCollaborator(data as EntryCollaboratorRow);
+}
+
+export async function updateEntryCollaboratorRole(
+  collaboratorId: string,
+  role: EntryCollaboratorRole
+): Promise<void> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('entry_collaborators').update({ role }).eq('id', collaboratorId);
+  if (error) throw error;
+}
+
+export async function removeEntryCollaborator(collaboratorId: string): Promise<void> {
+  const sb = assertSupabase();
+  const { error } = await sb.from('entry_collaborators').delete().eq('id', collaboratorId);
   if (error) throw error;
 }
 

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -367,10 +367,28 @@ export function createEmptyEntry(date: string, promptText?: string): Entry {
     is_draft: true,
     chapter_id: null,
     photos: [],
+    collaboration_role: 'owner',
     prompt_used: promptText || null,
     created_at: now,
     updated_at: now
   };
+}
+
+export function isEntryOwner(entry: Entry, userId?: string | null): boolean {
+  return !!userId && entry.user_id === userId;
+}
+
+export function canEditEntry(entry: Entry, userId?: string | null): boolean {
+  if (!entry.user_id) return true;
+  return isEntryOwner(entry, userId) || entry.collaboration_role === 'editor';
+}
+
+export function canManageEntryCollaborators(entry: Entry, userId?: string | null): boolean {
+  return isEntryOwner(entry, userId);
+}
+
+export function canManageEntryPhotos(entry: Entry, userId?: string | null): boolean {
+  return isEntryOwner(entry, userId) || !entry.user_id;
 }
 
 export function formatDate(dateStr: string): string {
@@ -400,7 +418,7 @@ export function getMonthFromDate(dateStr: string): string {
   return date.toLocaleDateString('en-US', { month: 'long' });
 }
 
-export function getAvailableYears(_entries: Entry[]): number[] {
+export function getAvailableYears(): number[] {
   const currentYear = new Date().getFullYear();
   const years: number[] = [];
   for (let year = currentYear; year >= currentYear - 100; year--) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,7 @@ export const CHAPTER_COLORS = [
 
 export interface Entry {
   id: string;
+  user_id?: string;
   date: string;
   title_user: string | null;
   title_ai: string | null;
@@ -67,7 +68,25 @@ export interface Entry {
   is_draft: boolean;
   chapter_id: string | null;
   photos: Photo[];
+  collaborators?: EntryCollaborator[];
+  collaboration_role?: EntryAccessRole;
   prompt_used: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type EntryCollaboratorRole = 'editor' | 'viewer';
+export type EntryCollaboratorStatus = 'pending' | 'accepted';
+export type EntryAccessRole = 'owner' | EntryCollaboratorRole;
+
+export interface EntryCollaborator {
+  id: string;
+  entry_id: string;
+  owner_id: string;
+  collaborator_user_id: string | null;
+  invitee_email: string;
+  role: EntryCollaboratorRole;
+  status: EntryCollaboratorStatus;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20260429123000_entry_collaboration.sql
+++ b/supabase/migrations/20260429123000_entry_collaboration.sql
@@ -1,0 +1,203 @@
+-- Entry-level collaboration for shared memories.
+
+set check_function_bodies = off;
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+create or replace function public.normalize_email(email text)
+returns text
+language sql
+immutable
+as $$
+  select lower(trim(email));
+$$;
+
+create or replace function public.current_user_email()
+returns text
+language sql
+stable
+as $$
+  select public.normalize_email(auth.jwt() ->> 'email');
+$$;
+
+create table public.entry_collaborators (
+  id                     uuid primary key default gen_random_uuid(),
+  entry_id               uuid not null references public.entries(id) on delete cascade,
+  owner_id               uuid not null references auth.users(id) on delete cascade,
+  collaborator_user_id   uuid references auth.users(id) on delete cascade,
+  invitee_email          text not null,
+  role                   text not null default 'editor' check (role in ('editor', 'viewer')),
+  status                 text not null default 'pending' check (status in ('pending', 'accepted')),
+  created_at             timestamptz not null default now(),
+  updated_at             timestamptz not null default now(),
+  constraint entry_collaborators_email_not_empty check (length(public.normalize_email(invitee_email)) > 0)
+);
+
+create unique index entry_collaborators_entry_email_idx
+  on public.entry_collaborators(entry_id, public.normalize_email(invitee_email));
+
+create index entry_collaborators_owner_idx on public.entry_collaborators(owner_id, updated_at desc);
+create index entry_collaborators_user_idx on public.entry_collaborators(collaborator_user_id)
+  where collaborator_user_id is not null;
+create index entry_collaborators_email_idx on public.entry_collaborators(public.normalize_email(invitee_email));
+
+create trigger entry_collaborators_set_updated_at
+  before update on public.entry_collaborators
+  for each row execute function public.set_updated_at();
+
+alter table public.entry_collaborators enable row level security;
+
+create or replace function public.can_select_entry(p_entry_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.entries e
+    where e.id = p_entry_id
+      and e.user_id = auth.uid()
+  ) or exists (
+    select 1
+    from public.entry_collaborators c
+    where c.entry_id = p_entry_id
+      and (
+        c.collaborator_user_id = auth.uid()
+        or public.normalize_email(c.invitee_email) = public.current_user_email()
+      )
+  );
+$$;
+
+create or replace function public.can_edit_entry(p_entry_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.entries e
+    where e.id = p_entry_id
+      and e.user_id = auth.uid()
+  ) or exists (
+    select 1
+    from public.entry_collaborators c
+    where c.entry_id = p_entry_id
+      and c.role = 'editor'
+      and (
+        c.collaborator_user_id = auth.uid()
+        or public.normalize_email(c.invitee_email) = public.current_user_email()
+      )
+  );
+$$;
+
+create or replace function public.is_entry_owner(p_entry_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.entries e
+    where e.id = p_entry_id
+      and e.user_id = auth.uid()
+  );
+$$;
+
+create or replace function public.claim_entry_collaborator_invites(p_email text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if public.normalize_email(p_email) <> public.current_user_email() then
+    raise exception 'Cannot claim collaborator invites for a different email';
+  end if;
+
+  update public.entry_collaborators
+     set collaborator_user_id = auth.uid(),
+         status = 'accepted'
+   where public.normalize_email(invitee_email) = public.current_user_email()
+     and (collaborator_user_id is null or collaborator_user_id = auth.uid());
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Collaborator policies
+-- ---------------------------------------------------------------------------
+
+create policy "entry_collaborators: related users can select"
+  on public.entry_collaborators for select
+  using (
+    owner_id = auth.uid()
+    or collaborator_user_id = auth.uid()
+    or public.normalize_email(invitee_email) = public.current_user_email()
+  );
+
+create policy "entry_collaborators: owner can insert"
+  on public.entry_collaborators for insert
+  with check (
+    owner_id = auth.uid()
+    and public.is_entry_owner(entry_id)
+    and public.normalize_email(invitee_email) <> public.current_user_email()
+  );
+
+create policy "entry_collaborators: owner can update"
+  on public.entry_collaborators for update
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid() and public.is_entry_owner(entry_id));
+
+create policy "entry_collaborators: owner can delete"
+  on public.entry_collaborators for delete
+  using (owner_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- Entries: owner plus collaborators can read, owner/editor can update.
+-- ---------------------------------------------------------------------------
+
+drop policy if exists "entries: owner can select" on public.entries;
+drop policy if exists "entries: owner can update" on public.entries;
+drop policy if exists "entries: owner can delete" on public.entries;
+
+create policy "entries: owner and collaborators can select"
+  on public.entries for select
+  using (public.can_select_entry(id));
+
+create policy "entries: owner and editors can update"
+  on public.entries for update
+  using (public.can_edit_entry(id))
+  with check (public.can_edit_entry(id));
+
+create policy "entries: owner can delete"
+  on public.entries for delete
+  using (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- Entry photos: collaborators can read shared photos, owner manages them.
+-- ---------------------------------------------------------------------------
+
+drop policy if exists "entry_photos: owner can select" on public.entry_photos;
+
+create policy "entry_photos: owner and collaborators can select"
+  on public.entry_photos for select
+  using (auth.uid() = user_id or public.can_select_entry(entry_id));
+
+drop policy if exists "journal-photos: owner can select" on storage.objects;
+
+create policy "journal-photos: owner and collaborators can select"
+  on storage.objects for select
+  using (
+    bucket_id = 'journal-photos'
+    and (
+      auth.uid()::text = split_part(name, '/', 1)
+      or public.can_select_entry(nullif(split_part(name, '/', 2), '')::uuid)
+    )
+  );

--- a/tests/entry-collaboration.test.ts
+++ b/tests/entry-collaboration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { canEditEntry, canManageEntryCollaborators, canManageEntryPhotos, isEntryOwner } from '../src/lib/entries';
+import { Entry } from '../src/lib/types';
+
+function entryFor(role: Entry['collaboration_role'], ownerId = 'owner-user'): Entry {
+  const now = '2026-04-29T10:00:00.000Z';
+  return {
+    id: 'entry-1',
+    user_id: ownerId,
+    date: '2026-04-29',
+    title_user: 'A shared day',
+    title_ai: null,
+    transcript: 'We wrote this memory together.',
+    story_ai: null,
+    highlights_ai: null,
+    tags_ai: null,
+    location_suggestions: null,
+    manual_locations: null,
+    missing_info_questions: null,
+    uncertain_claims: null,
+    is_locked: false,
+    is_starred: false,
+    is_draft: false,
+    chapter_id: null,
+    photos: [],
+    collaborators: [],
+    collaboration_role: role,
+    prompt_used: null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+describe('entry collaboration permissions', () => {
+  it('lets the owner edit, manage collaborators, and manage photos', () => {
+    const entry = entryFor('owner');
+
+    expect(isEntryOwner(entry, 'owner-user')).toBe(true);
+    expect(canEditEntry(entry, 'owner-user')).toBe(true);
+    expect(canManageEntryCollaborators(entry, 'owner-user')).toBe(true);
+    expect(canManageEntryPhotos(entry, 'owner-user')).toBe(true);
+  });
+
+  it('lets editor collaborators edit without managing collaborators or photos', () => {
+    const entry = entryFor('editor');
+
+    expect(isEntryOwner(entry, 'collaborator-user')).toBe(false);
+    expect(canEditEntry(entry, 'collaborator-user')).toBe(true);
+    expect(canManageEntryCollaborators(entry, 'collaborator-user')).toBe(false);
+    expect(canManageEntryPhotos(entry, 'collaborator-user')).toBe(false);
+  });
+
+  it('keeps viewer collaborators read-only', () => {
+    const entry = entryFor('viewer');
+
+    expect(canEditEntry(entry, 'viewer-user')).toBe(false);
+    expect(canManageEntryCollaborators(entry, 'viewer-user')).toBe(false);
+    expect(canManageEntryPhotos(entry, 'viewer-user')).toBe(false);
+  });
+});


### PR DESCRIPTION
Memories are currently private, single-owner entries. This adds an entry-level collaboration MVP so people can invite trusted collaborators to view or help write a memory together while keeping existing memories private by default.

## Summary

- Adds a Supabase collaboration migration with `entry_collaborators`, owner/editor/viewer policies, invite claiming by email, and shared photo read access.
- Updates entry fetching and save permissions so owned and shared memories load through the same journal surfaces.
- Adds a `Collaborate on this memory` dialog for inviting collaborators, changing roles, viewing pending invites, and removing access.
- Adds UI guardrails for collaboration roles: owners manage collaborators/photos/deletion, editors can edit memory content, and viewers stay read-only.
- Adds shared-memory indicators and focused tests for collaboration permission helpers.

## Notes for reviewers

This is intentionally not realtime collaborative editing yet. The MVP uses normal save/reload behavior with last-save-wins semantics, while setting up role-aware access and UI affordances for future realtime presence or conflict handling.

Photo upload/delete remains owner-only for now, but collaborators with access can read shared entry photos through the new storage policy.

## Validation

- `npm run test`
- `npm run build`
- Changed-file lint via `npx eslint ... --quiet`

Full-repo lint still reports pre-existing unrelated lint errors in API/test files.