### PR TITLE
Refocus prompts on travel memories

### DIFF
--- a/src/components/screens/PromptsScreen.tsx
+++ b/src/components/screens/PromptsScreen.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AppView, Prompt, PromptCategory, DEFAULT_PROMPTS, PROMPT_CATEGORIES } from '@/lib/types';
 import { Button } from '@/components/ui/button';
-import { Sparkle, ArrowRight, NotePencil } from '@phosphor-icons/react';
+import { Sparkle, ArrowRight, NotePencil, ArrowsClockwise } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import { SettingsPanel } from '@/components/SettingsPanel';
 import { LogoHomeButton } from '@/components/LogoHomeButton';
@@ -15,16 +15,38 @@ interface PromptsScreenProps {
   onNavigate: (view: AppView) => void;
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function getLocalDayNumber(date = new Date()): number {
+  return Math.floor(new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() / MS_PER_DAY);
+}
+
+function getMsUntilTomorrow(): number {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).getTime() - now.getTime();
+}
+
 export function PromptsScreen({ onNavigate }: PromptsScreenProps) {
   const { themeMode, setThemeMode, isDarkMode, isNightTime } = useTheme();
   const { t } = useLanguage();
   const [selectedCategory, setSelectedCategory] = useState<PromptCategory | null>(null);
+  const [dailyPromptDay, setDailyPromptDay] = useState(getLocalDayNumber);
+  const [dailyPromptOffset, setDailyPromptOffset] = useState(0);
   
-  const todaysPrompt = DEFAULT_PROMPTS[Math.floor(Date.now() / 86400000) % DEFAULT_PROMPTS.length];
+  const todaysPrompt = DEFAULT_PROMPTS[(dailyPromptDay + dailyPromptOffset) % DEFAULT_PROMPTS.length];
   
   const filteredPrompts = selectedCategory
     ? DEFAULT_PROMPTS.filter(p => p.category === selectedCategory)
     : DEFAULT_PROMPTS;
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDailyPromptDay(getLocalDayNumber());
+      setDailyPromptOffset(0);
+    }, getMsUntilTomorrow());
+
+    return () => window.clearTimeout(timeout);
+  }, [dailyPromptDay]);
 
   const handleSelectPrompt = (prompt: Prompt) => {
     onNavigate({ type: 'prompts-new', promptId: prompt.id });
@@ -32,6 +54,10 @@ export function PromptsScreen({ onNavigate }: PromptsScreenProps) {
 
   const handleCustomMemory = () => {
     onNavigate({ type: 'prompts-new' });
+  };
+
+  const handleRefreshDailyPrompt = () => {
+    setDailyPromptOffset(offset => (offset + 1) % DEFAULT_PROMPTS.length);
   };
 
   const handleSelectMoment = (suggestion: MomentSuggestion) => {
@@ -113,7 +139,18 @@ export function PromptsScreen({ onNavigate }: PromptsScreenProps) {
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.05 }}
         >
-          <p className="text-sm font-medium text-muted-foreground mb-3">{t.prompts.daily}</p>
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-sm font-medium text-muted-foreground">{t.prompts.daily}</p>
+            <button
+              type="button"
+              onClick={handleRefreshDailyPrompt}
+              className="flex items-center gap-1 text-xs text-muted-foreground/70 hover:text-foreground"
+              aria-label={t.prompts.refresh}
+            >
+              <ArrowsClockwise weight="bold" className="h-3.5 w-3.5" />
+              {t.prompts.refresh}
+            </button>
+          </div>
           <div className="p-4 sm:p-6 rounded-2xl bg-gradient-to-br from-primary/15 via-accent/10 to-primary/5 border border-primary/20">
             <div className="flex items-start gap-4 mb-5">
               <div className="p-2 sm:p-3 rounded-xl bg-primary/20">

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -43,7 +43,7 @@ type TranslationKeys = {
   };
   prompts: {
     title: string; description: string; categories: string; allPrompts: string; useThis: string;
-    daily: string; reflection: string; gratitude: string; dreams: string; travel: string; relationships: string;
+    daily: string; refresh: string; reflection: string; gratitude: string; dreams: string; travel: string; relationships: string;
   };
   chapters: {
     title: string; description: string; newChapter: string; editChapter: string; deleteChapter: string;
@@ -106,7 +106,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     },
     prompts: {
       title: 'Prompts', description: 'Get inspired to write', categories: 'Categories', allPrompts: 'All Prompts',
-      useThis: 'Use this prompt', daily: 'Daily', reflection: 'Reflection', gratitude: 'Gratitude',
+      useThis: 'Use this prompt', daily: 'Daily', refresh: 'Refresh', reflection: 'Reflection', gratitude: 'Gratitude',
       dreams: 'Dreams', travel: 'Travel', relationships: 'Relationships'
     },
     chapters: {
@@ -172,7 +172,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     },
     prompts: {
       title: 'Impulse', description: 'Lass dich inspirieren', categories: 'Kategorien', allPrompts: 'Alle Impulse',
-      useThis: 'Diesen Impuls nutzen', daily: 'Täglich', reflection: 'Reflexion', gratitude: 'Dankbarkeit',
+      useThis: 'Diesen Impuls nutzen', daily: 'Täglich', refresh: 'Neu laden', reflection: 'Reflexion', gratitude: 'Dankbarkeit',
       dreams: 'Träume', travel: 'Reisen', relationships: 'Beziehungen'
     },
     chapters: {
@@ -238,7 +238,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     },
     prompts: {
       title: 'Sugerencias', description: 'Inspírate para escribir', categories: 'Categorías', allPrompts: 'Todas las Sugerencias',
-      useThis: 'Usar esta sugerencia', daily: 'Diario', reflection: 'Reflexión', gratitude: 'Gratitud',
+      useThis: 'Usar esta sugerencia', daily: 'Diario', refresh: 'Actualizar', reflection: 'Reflexión', gratitude: 'Gratitud',
       dreams: 'Sueños', travel: 'Viajes', relationships: 'Relaciones'
     },
     chapters: {
@@ -304,7 +304,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     },
     prompts: {
       title: 'Inspirations', description: 'Laissez-vous inspirer', categories: 'Catégories', allPrompts: 'Toutes les Inspirations',
-      useThis: 'Utiliser cette inspiration', daily: 'Quotidien', reflection: 'Réflexion', gratitude: 'Gratitude',
+      useThis: 'Utiliser cette inspiration', daily: 'Quotidien', refresh: 'Actualiser', reflection: 'Réflexion', gratitude: 'Gratitude',
       dreams: 'Rêves', travel: 'Voyages', relationships: 'Relations'
     },
     chapters: {
@@ -370,7 +370,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     },
     prompts: {
       title: 'Sugestões', description: 'Inspire-se para escrever', categories: 'Categorias', allPrompts: 'Todas as Sugestões',
-      useThis: 'Usar esta sugestão', daily: 'Diário', reflection: 'Reflexão', gratitude: 'Gratidão',
+      useThis: 'Usar esta sugestão', daily: 'Diário', refresh: 'Atualizar', reflection: 'Reflexão', gratitude: 'Gratidão',
       dreams: 'Sonhos', travel: 'Viagens', relationships: 'Relacionamentos'
     },
     chapters: {
@@ -436,7 +436,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     },
     prompts: {
       title: '提示', description: '获取写作灵感', categories: '分类', allPrompts: '所有提示',
-      useThis: '使用此提示', daily: '日常', reflection: '反思', gratitude: '感恩',
+      useThis: '使用此提示', daily: '日常', refresh: '刷新', reflection: '反思', gratitude: '感恩',
       dreams: '梦想', travel: '旅行', relationships: '关系'
     },
     chapters: {
@@ -502,7 +502,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
     },
     prompts: {
       title: 'プロンプト', description: 'インスピレーションを得る', categories: 'カテゴリー', allPrompts: 'すべてのプロンプト',
-      useThis: 'このプロンプトを使う', daily: '日常', reflection: '振り返り', gratitude: '感謝',
+      useThis: 'このプロンプトを使う', daily: '日常', refresh: '更新', reflection: '振り返り', gratitude: '感謝',
       dreams: '夢', travel: '旅行', relationships: '人間関係'
     },
     chapters: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -161,31 +161,31 @@ export interface Prompt {
 export type PromptCategory = 'gratitude' | 'reflection' | 'memory' | 'creative' | 'goals' | 'relationships';
 
 export const PROMPT_CATEGORIES: { value: PromptCategory; label: string; emoji: string }[] = [
-  { value: 'gratitude', label: 'Gratitude', emoji: '🙏' },
-  { value: 'reflection', label: 'Reflection', emoji: '🪞' },
-  { value: 'memory', label: 'Memory', emoji: '📸' },
-  { value: 'creative', label: 'Creative', emoji: '🎨' },
-  { value: 'goals', label: 'Goals', emoji: '🎯' },
-  { value: 'relationships', label: 'Relationships', emoji: '💕' },
+  { value: 'gratitude', label: 'Small details', emoji: '🔎' },
+  { value: 'reflection', label: 'Trips', emoji: '🧳' },
+  { value: 'memory', label: 'Places', emoji: '📍' },
+  { value: 'creative', label: 'Scenes', emoji: '🎞️' },
+  { value: 'goals', label: 'First times', emoji: '✨' },
+  { value: 'relationships', label: 'People', emoji: '👥' },
 ];
 
 export const DEFAULT_PROMPTS: Prompt[] = [
-  { id: '1', text: 'What made you smile today?', category: 'gratitude' },
-  { id: '2', text: 'Describe a place that feels like home.', category: 'memory' },
-  { id: '3', text: 'What would you tell your younger self?', category: 'reflection' },
-  { id: '4', text: 'Write about a person who changed your life.', category: 'relationships' },
-  { id: '5', text: 'What are you most proud of this week?', category: 'gratitude' },
-  { id: '6', text: 'Describe your perfect day from start to finish.', category: 'creative' },
-  { id: '7', text: 'What is a goal you are working towards?', category: 'goals' },
-  { id: '8', text: 'Write about a moment that took your breath away.', category: 'memory' },
-  { id: '9', text: 'What does success mean to you?', category: 'reflection' },
-  { id: '10', text: 'Describe someone you admire and why.', category: 'relationships' },
-  { id: '11', text: 'What are three things you are grateful for today?', category: 'gratitude' },
-  { id: '12', text: 'Write about a challenge you overcame.', category: 'reflection' },
-  { id: '13', text: 'Describe a dream you had recently.', category: 'creative' },
-  { id: '14', text: 'What adventure would you like to have?', category: 'goals' },
-  { id: '15', text: 'Write about a favorite childhood memory.', category: 'memory' },
-  { id: '16', text: 'What makes you feel most alive?', category: 'reflection' },
+  { id: '1', text: 'Write about a vacation morning you still remember clearly: where did you wake up, and what did the day sound like?', category: 'reflection' },
+  { id: '2', text: 'Describe a place from a trip that you can still picture when you close your eyes.', category: 'memory' },
+  { id: '3', text: 'Tell the story of a meal, snack, or drink from a trip that became part of the memory.', category: 'gratitude' },
+  { id: '4', text: 'Write about someone you travelled with and a small moment between you that stayed with you.', category: 'relationships' },
+  { id: '5', text: 'Remember a journey there or back: the train, car, airport, ferry, road, or waiting time.', category: 'reflection' },
+  { id: '6', text: 'Describe a photo you wish you had taken on a vacation, and what was happening around it.', category: 'creative' },
+  { id: '7', text: 'Write about the first time you arrived somewhere new on a trip.', category: 'goals' },
+  { id: '8', text: 'Capture a tiny detail from a holiday place: a smell, a sound, a color, or the weather.', category: 'gratitude' },
+  { id: '9', text: 'Tell the story of getting lost, taking a detour, or discovering something by accident while travelling.', category: 'reflection' },
+  { id: '10', text: 'Describe a vacation tradition your family, friends, or partner always seemed to repeat.', category: 'relationships' },
+  { id: '11', text: 'Write about the room, tent, apartment, or hotel where you stayed on a memorable trip.', category: 'memory' },
+  { id: '12', text: 'Remember a beach, mountain, city street, lake, forest, or view that felt important at the time.', category: 'memory' },
+  { id: '13', text: 'Tell the story behind a souvenir, ticket, postcard, shell, or object you kept from a trip.', category: 'creative' },
+  { id: '14', text: 'Write about a vacation moment that felt like a first: first swim, first flight, first big city, or first time away.', category: 'goals' },
+  { id: '15', text: 'Describe a childhood holiday memory as a scene: who was there, where were you, and what happened next?', category: 'memory' },
+  { id: '16', text: 'Write about the last evening of a trip and what you did before leaving.', category: 'reflection' },
 ];
 
 export type NavigationTab = 'home' | 'prompts' | 'library' | 'print';


### PR DESCRIPTION
Daily prompts felt too reflection-oriented for Memory Journal's core purpose. This reframes the suggestions around concrete memories from trips, holidays, places, people, and small sensory details so they better support capturing memories instead of self-reflection.

## What changed

- Replaced the default prompt set with memory-first vacation and travel prompts.
- Renamed prompt categories to fit the new memory-oriented framing, such as Trips, Places, People, Small details, Scenes, and First times.
- Added a manual refresh control for the daily prompt while preserving automatic daily rotation at the next local calendar day.
- Added localized refresh labels for supported app languages.

## Notes

The global lint command still has pre-existing failures in unrelated files. Targeted lint for the changed files and the production build pass.