### PR TITLE
Set light theme as default

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useJournalData } from './hooks/use-journal-data';
 import { canEditEntry } from './lib/entries';
 import { motion, AnimatePresence } from 'framer-motion';
 import { supabase } from './lib/supabase';
+import { setNativeStatusBarTheme } from './lib/capacitor';
 
 import { HomeScreen } from './components/screens/HomeScreen';
 import { SettingsPanel } from './components/SettingsPanel';
@@ -71,6 +72,7 @@ function AppContent() {
     } else {
       document.documentElement.classList.remove('dark-mode');
     }
+    void setNativeStatusBarTheme(isDarkMode);
   }, [isDarkMode]);
 
   const navigate = useCallback((view: AppView) => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -24,6 +24,7 @@ import {
   Sun, 
   Moon, 
   CircleHalf, 
+  Desktop,
   User, 
   Bell, 
   Globe, 
@@ -310,6 +311,32 @@ export function SettingsPanel({
               onValueChange={(v) => resolvedOnThemeModeChange(v as ThemeMode)}
               className="space-y-2"
             >
+              <motion.label 
+                whileHover={{ scale: 1.01 }}
+                whileTap={{ scale: 0.99 }}
+                className={`flex items-center gap-4 p-4 rounded-xl border-2 cursor-pointer transition-all ${
+                  resolvedThemeMode === 'system' 
+                    ? 'border-primary bg-primary/10' 
+                    : 'border-border/50 hover:border-border'
+                }`}
+              >
+                <RadioGroupItem value="system" id="system" className="sr-only" />
+                <div className={`p-2.5 rounded-lg ${resolvedThemeMode === 'system' ? 'bg-primary/20' : 'bg-muted/50'}`}>
+                  <Desktop weight="duotone" className={`w-5 h-5 ${resolvedThemeMode === 'system' ? 'text-primary' : 'text-muted-foreground'}`} />
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium text-foreground">{t.settings.system}</p>
+                  <p className="text-xs text-muted-foreground">{t.settings.systemDesc}</p>
+                </div>
+                {resolvedThemeMode === 'system' && (
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    className="w-2 h-2 rounded-full bg-primary"
+                  />
+                )}
+              </motion.label>
+
               <motion.label 
                 whileHover={{ scale: 1.01 }}
                 whileTap={{ scale: 0.99 }}
@@ -806,4 +833,3 @@ function SettingRow({
     </div>
   );
 }
-

--- a/src/hooks/use-night-mode.ts
+++ b/src/hooks/use-night-mode.ts
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import { useLocalStorage } from './use-local-storage';
 import { ThemeMode } from '@/lib/types';
 
+export const DEFAULT_THEME_MODE: ThemeMode = 'light';
+
 function getSunTimes(): { sunrise: Date; sunset: Date } {
   const now = new Date();
   const year = now.getFullYear();
@@ -27,9 +29,29 @@ function isNightTime(): boolean {
   return currentTimeInMinutes < sunriseMinutes || currentTimeInMinutes >= sunsetMinutes;
 }
 
+export function getSystemPrefersDark(): boolean {
+  return typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-color-scheme: dark)').matches === true;
+}
+
+export function resolveThemeMode(themeMode: ThemeMode | undefined, isNight: boolean, systemPrefersDark: boolean): 'light' | 'dark' {
+  switch (themeMode || DEFAULT_THEME_MODE) {
+    case 'dark':
+      return 'dark';
+    case 'system':
+      return systemPrefersDark ? 'dark' : 'light';
+    case 'auto':
+      return isNight ? 'dark' : 'light';
+    case 'light':
+    default:
+      return 'light';
+  }
+}
+
 export function useNightMode() {
-  const [themeMode, setThemeMode] = useLocalStorage<ThemeMode>('tightly-theme-mode', 'auto');
+  const [themeMode, setThemeMode] = useLocalStorage<ThemeMode>('tightly-theme-mode', DEFAULT_THEME_MODE);
   const [isNight, setIsNight] = useState(isNightTime());
+  const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark());
   
   useEffect(() => {
     const checkTime = () => {
@@ -42,21 +64,28 @@ export function useNightMode() {
     
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const updateSystemTheme = () => setSystemPrefersDark(mediaQuery.matches);
+
+    updateSystemTheme();
+    mediaQuery.addEventListener('change', updateSystemTheme);
+
+    return () => mediaQuery.removeEventListener('change', updateSystemTheme);
+  }, []);
   
-  const effectiveTheme = (() => {
-    if (themeMode === 'auto') {
-      return isNight ? 'dark' : 'light';
-    }
-    return themeMode;
-  })();
+  const effectiveTheme = resolveThemeMode(themeMode, isNight, systemPrefersDark);
   
   const isDarkMode = effectiveTheme === 'dark';
   
   return {
-    themeMode: themeMode || 'auto',
+    themeMode: themeMode || DEFAULT_THEME_MODE,
     setThemeMode,
     isDarkMode,
-    isAutoMode: (themeMode || 'auto') === 'auto',
+    isAutoMode: (themeMode || DEFAULT_THEME_MODE) === 'auto',
     isNightTime: isNight,
   };
 }

--- a/src/lib/capacitor.ts
+++ b/src/lib/capacitor.ts
@@ -13,18 +13,20 @@ export function isNative(): boolean {
   return Capacitor.isNativePlatform();
 }
 
-export async function initCapacitor(): Promise<void> {
+export async function setNativeStatusBarTheme(isDarkMode: boolean): Promise<void> {
   if (!isNative()) return;
 
-  // Match status bar to the current system theme. StatusBar APIs are no-ops on
-  // web; calling them without guards is fine but we guard anyway for clarity.
   try {
-    const prefersDark = typeof window !== 'undefined'
-      && window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-    await StatusBar.setStyle({ style: prefersDark ? Style.Dark : Style.Light });
+    await StatusBar.setStyle({ style: isDarkMode ? Style.Dark : Style.Light });
   } catch {
     // Status bar styling is best-effort; ignore failures.
   }
+}
+
+export async function initCapacitor(): Promise<void> {
+  if (!isNative()) return;
+
+  await setNativeStatusBarTheme(false);
 
   // Hide the native splash quickly once React has painted.
   try {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -31,7 +31,7 @@ type TranslationKeys = {
     account: string; privacy: string; privacyDesc: string; exportData: string; exportDataDesc: string; 
     notifications: string; pushNotifications: string; pushNotificationsDesc: string; emailUpdates: string; emailUpdatesDesc: string; 
     preferences: string; autoSave: string; autoSaveDesc: string; 
-    appearance: string; currentMode: string; night: string; day: string; automatic: string; automaticDesc: string; 
+    appearance: string; currentMode: string; night: string; day: string; system: string; systemDesc: string; automatic: string; automaticDesc: string; 
     alwaysLight: string; alwaysLightDesc: string; alwaysNight: string; alwaysNightDesc: string; 
     about: string; version: string; versionDesc: string; signOut: string; deleteAccount: string; view: string; export: string 
   };
@@ -88,6 +88,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
       emailUpdates: 'Email Updates', emailUpdatesDesc: 'Weekly memory digest', 
       preferences: 'Preferences', autoSave: 'Auto-save', autoSaveDesc: 'Save entries automatically', 
       appearance: 'Appearance', currentMode: 'Current mode', night: 'Night', day: 'Day', 
+      system: 'System', systemDesc: 'Follow device appearance when selected',
       automatic: 'Automatic', automaticDesc: 'Switches at sunset & sunrise', 
       alwaysLight: 'Always Light', alwaysLightDesc: 'Bright & airy daytime sky', 
       alwaysNight: 'Always Night', alwaysNightDesc: 'Stars & aurora at all times', 
@@ -154,6 +155,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
       emailUpdates: 'E-Mail-Updates', emailUpdatesDesc: 'Wöchentliche Zusammenfassung', 
       preferences: 'Einstellungen', autoSave: 'Auto-Speichern', autoSaveDesc: 'Einträge automatisch speichern', 
       appearance: 'Erscheinungsbild', currentMode: 'Aktueller Modus', night: 'Nacht', day: 'Tag', 
+      system: 'System', systemDesc: 'Folgt nur bei Auswahl dem Geräte-Design',
       automatic: 'Automatisch', automaticDesc: 'Wechselt bei Sonnenuntergang & -aufgang', 
       alwaysLight: 'Immer Hell', alwaysLightDesc: 'Heller Tageshimmel', 
       alwaysNight: 'Immer Dunkel', alwaysNightDesc: 'Sterne & Aurora jederzeit', 
@@ -220,6 +222,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
       emailUpdates: 'Actualizaciones por Email', emailUpdatesDesc: 'Resumen semanal', 
       preferences: 'Preferencias', autoSave: 'Auto-guardar', autoSaveDesc: 'Guardar entradas automáticamente', 
       appearance: 'Apariencia', currentMode: 'Modo actual', night: 'Noche', day: 'Día', 
+      system: 'Sistema', systemDesc: 'Sigue la apariencia del dispositivo al seleccionarlo',
       automatic: 'Automático', automaticDesc: 'Cambia al atardecer y amanecer', 
       alwaysLight: 'Siempre Claro', alwaysLightDesc: 'Cielo diurno brillante', 
       alwaysNight: 'Siempre Oscuro', alwaysNightDesc: 'Estrellas y aurora siempre', 
@@ -286,6 +289,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
       emailUpdates: 'Mises à jour par Email', emailUpdatesDesc: 'Résumé hebdomadaire', 
       preferences: 'Préférences', autoSave: 'Sauvegarde auto', autoSaveDesc: 'Sauvegarder automatiquement', 
       appearance: 'Apparence', currentMode: 'Mode actuel', night: 'Nuit', day: 'Jour', 
+      system: 'Système', systemDesc: "Suit l'apparence de l'appareil si sélectionné",
       automatic: 'Automatique', automaticDesc: 'Change au coucher/lever du soleil', 
       alwaysLight: 'Toujours Clair', alwaysLightDesc: 'Ciel de jour lumineux', 
       alwaysNight: 'Toujours Sombre', alwaysNightDesc: 'Étoiles et aurores toujours', 
@@ -352,6 +356,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
       emailUpdates: 'Atualizações por Email', emailUpdatesDesc: 'Resumo semanal', 
       preferences: 'Preferências', autoSave: 'Salvar automático', autoSaveDesc: 'Salvar entradas automaticamente', 
       appearance: 'Aparência', currentMode: 'Modo atual', night: 'Noite', day: 'Dia', 
+      system: 'Sistema', systemDesc: 'Segue a aparência do dispositivo quando selecionado',
       automatic: 'Automático', automaticDesc: 'Muda ao pôr/nascer do sol', 
       alwaysLight: 'Sempre Claro', alwaysLightDesc: 'Céu diurno brilhante', 
       alwaysNight: 'Sempre Escuro', alwaysNightDesc: 'Estrelas e aurora sempre', 
@@ -418,6 +423,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
       emailUpdates: '邮件更新', emailUpdatesDesc: '每周回忆摘要', 
       preferences: '偏好设置', autoSave: '自动保存', autoSaveDesc: '自动保存条目', 
       appearance: '外观', currentMode: '当前模式', night: '夜间', day: '日间', 
+      system: '系统', systemDesc: '仅在选择时跟随设备外观',
       automatic: '自动', automaticDesc: '日落日出自动切换', 
       alwaysLight: '始终明亮', alwaysLightDesc: '明亮的日间天空', 
       alwaysNight: '始终夜间', alwaysNightDesc: '永远星空极光', 
@@ -484,6 +490,7 @@ const translations: Record<AppLanguage, TranslationKeys> = {
       emailUpdates: 'メール更新', emailUpdatesDesc: '週間ダイジェスト', 
       preferences: '設定', autoSave: '自動保存', autoSaveDesc: 'エントリを自動保存', 
       appearance: '外観', currentMode: '現在のモード', night: '夜', day: '昼', 
+      system: 'システム', systemDesc: '選択時のみデバイスの外観に従う',
       automatic: '自動', automaticDesc: '日の出と日没で切り替え', 
       alwaysLight: '常にライト', alwaysLightDesc: '明るい昼間の空', 
       alwaysNight: '常にダーク', alwaysNightDesc: '常に星空とオーロラ', 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -230,7 +230,7 @@ export const STORY_LANGUAGES = [
   { code: 'zh', label: '中文', flag: '🇨🇳' },
 ];
 
-export type ThemeMode = 'auto' | 'light' | 'dark';
+export type ThemeMode = 'light' | 'dark' | 'system' | 'auto';
 
 export interface UserSettings {
   themeMode: ThemeMode;

--- a/tests/theme-mode.test.ts
+++ b/tests/theme-mode.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_THEME_MODE, resolveThemeMode } from '../src/hooks/use-night-mode';
+
+describe('theme mode resolution', () => {
+  it('defaults to light mode instead of automatic night mode', () => {
+    expect(DEFAULT_THEME_MODE).toBe('light');
+    expect(resolveThemeMode(undefined, true, true)).toBe('light');
+  });
+
+  it('only follows system dark mode when system mode is selected', () => {
+    expect(resolveThemeMode('light', true, true)).toBe('light');
+    expect(resolveThemeMode('system', false, true)).toBe('dark');
+    expect(resolveThemeMode('system', true, false)).toBe('light');
+  });
+
+  it('keeps explicit night and automatic sunset modes available', () => {
+    expect(resolveThemeMode('dark', false, false)).toBe('dark');
+    expect(resolveThemeMode('auto', true, false)).toBe('dark');
+    expect(resolveThemeMode('auto', false, true)).toBe('light');
+  });
+});


### PR DESCRIPTION
Night mode was previously enabled automatically by the default theme setting, which could make the app dark even when the user had not opted in. This change makes the app default to light mode and keeps darker behavior behind explicit settings.

## Summary
- Default the persisted theme mode to `light` instead of automatic night mode.
- Add an explicit `System` appearance option that follows the device theme only when selected.
- Keep manual dark mode and automatic sunset/sunrise mode available as opt-in choices.
- Sync the native status bar with the resolved app theme instead of defaulting from system preferences.
- Add coverage for default, system, automatic, and explicit dark theme resolution.

## Validation
- `npm run build`
- `npm test`
- `npx eslint src/App.tsx src/components/SettingsPanel.tsx src/hooks/use-night-mode.ts src/lib/capacitor.ts src/lib/i18n.ts src/lib/types.ts tests/theme-mode.test.ts`

Note: `npm run lint` still reports existing unrelated lint issues across untouched API, screen, and test files.